### PR TITLE
fix: cron rappels à 7h UTC (9h Paris heure d'été)

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -268,7 +268,7 @@ NEXTAUTH_URL=               # URL du site
 NEXTAUTH_SECRET=            # Secret JWT
 RESEND_API_KEY=             # Clé API Resend
 EMAIL_FROM=                 # Email expéditeur
-CRON_SECRET=                # Secret pour le cron de rappels
+CRON_SECRET=                # Secret pour le cron de rappels (7h UTC = 9h Paris)
 ```
 
 ### Commandes
@@ -387,7 +387,7 @@ Exemple de workflow :
 | Push sur `main` | Déploiement automatique en **production** |
 | Push sur `dev` | Déploiement **preview** (URL temporaire) |
 | Pull Request | Déploiement **preview** + CI pipeline |
-| Cron quotidien 9h UTC | Exécution `/api/cron/reminders` (rappels email) |
+| Cron quotidien 7h UTC (9h Paris) | Exécution `/api/cron/reminders` (rappels email inactivité 3j) |
 
 Configuration :
 1. Variables d'environnement dans Vercel Dashboard

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 9 * * *"
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Description

Corrections et ajustements finaux avant mise en production.

### Changements
- Heure du cron de rappels ajustée : 9h UTC → 7h UTC (= 9h heure de Paris)
- Documentation technique mise à jour avec l'heure correcte du cron
- Corrections mineures de documentation

## Type de changement

- [x] 🔧 Refactoring
- [x] 📝 Documentation

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [ ] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [x] La documentation a été mise à jour si nécessaire
- [x] Les migrations Prisma sont incluses si nécessaire
