### PR TITLE
feat: modules many-to-many — un module peut appartenir à plusieurs pa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ docs/brainstorming-session-results.md
 docs/prd.md
 .gitignore
 docs/front-end-spec.md
+scripts/migrate-modules-to-many-to-many.sql

--- a/app/(dashboard)/admin/docs/DocsPageClient.tsx
+++ b/app/(dashboard)/admin/docs/DocsPageClient.tsx
@@ -7,7 +7,7 @@ import rehypeHighlight from 'rehype-highlight'
 import 'highlight.js/styles/github-dark.min.css'
 import { Card, CardContent } from '@/components/ui/card'
 import {
-  FileText, List, ChevronRight, Folder, FolderOpen, File,
+  FileText, ChevronRight, Folder, FolderOpen, File,
   FileCode, FileJson, Database, Globe, Shield, Settings, Terminal,
   Palette, Layout, Braces, Server, TestTube, BookOpen, Cog,
   Layers, Rocket, Lock, Wrench, Users, BarChart3, Workflow,

--- a/app/(dashboard)/learner/certificates/page.tsx
+++ b/app/(dashboard)/learner/certificates/page.tsx
@@ -19,7 +19,7 @@ export default async function CertificatesPage() {
     include: {
       parcours: {
         include: {
-          modules: { select: { id: true } },
+          parcoursModules: { select: { moduleId: true } },
         },
       },
     },
@@ -36,12 +36,12 @@ export default async function CertificatesPage() {
   // Find parcours where all modules are completed
   const completedParcours = assignments
     .filter((a) => {
-      const moduleIds = a.parcours.modules.map((m) => m.id)
+      const moduleIds = a.parcours.parcoursModules.map((pm) => pm.moduleId)
       return moduleIds.length > 0 && moduleIds.every((id) => completedSet.has(id))
     })
     .map((a) => {
       // Find latest completion date for this parcours
-      const moduleIds = new Set(a.parcours.modules.map((m) => m.id))
+      const moduleIds = new Set(a.parcours.parcoursModules.map((pm) => pm.moduleId))
       const dates = completedModuleIds
         .filter((p) => moduleIds.has(p.moduleId))
         .map((p) => p.completedAt)
@@ -50,7 +50,7 @@ export default async function CertificatesPage() {
       return {
         id: a.parcours.id,
         title: a.parcours.title,
-        moduleCount: a.parcours.modules.length,
+        moduleCount: a.parcours.parcoursModules.length,
         completedAt: latestDate,
       }
     })

--- a/app/(dashboard)/learner/quiz-history/page.tsx
+++ b/app/(dashboard)/learner/quiz-history/page.tsx
@@ -26,7 +26,10 @@ export default async function QuizHistoryPage() {
             select: {
               id: true,
               title: true,
-              parcours: { select: { id: true, title: true } },
+              parcoursModules: {
+                select: { parcours: { select: { id: true, title: true } } },
+                take: 1,
+              },
             },
           },
         },
@@ -113,7 +116,7 @@ export default async function QuizHistoryPage() {
                         <span className="font-medium truncate">{result.progress.module.title}</span>
                         <Badge variant="secondary" className="text-xs shrink-0">
                           <BookOpen className="h-3 w-3 mr-1" />
-                          {result.progress.module.parcours.title}
+                          {result.progress.module.parcoursModules[0]?.parcours?.title ?? 'Parcours'}
                         </Badge>
                       </div>
                       <div className="flex items-center gap-3 text-sm text-muted-foreground">

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -60,7 +60,7 @@ async function exportLearners(): Promise<string> {
           parcours: {
             select: {
               title: true,
-              modules: { select: { id: true } },
+              parcoursModules: { select: { moduleId: true } },
             },
           },
         },
@@ -83,7 +83,7 @@ async function exportLearners(): Promise<string> {
 
   const dataRows = learnersWithProgress.map((l) => {
     const parcoursTitles = l.userParcours.map((up) => up.parcours.title).join(', ')
-    const totalModules = l.userParcours.reduce((acc, up) => acc + up.parcours.modules.length, 0)
+    const totalModules = l.userParcours.reduce((acc, up) => acc + up.parcours.parcoursModules.length, 0)
     const completedModules = l.progress.length
     const percentage = totalModules > 0 ? Math.round((completedModules / totalModules) * 100) : 0
 
@@ -109,7 +109,10 @@ async function exportProgress(): Promise<string> {
       module: {
         select: {
           title: true,
-          parcours: { select: { title: true } },
+          parcoursModules: {
+            select: { parcours: { select: { title: true } } },
+            take: 1,
+          },
         },
       },
     },
@@ -128,7 +131,7 @@ async function exportProgress(): Promise<string> {
     csvRow([
       p.user.name,
       p.user.email,
-      p.module.parcours?.title || 'N/A',
+      p.module.parcoursModules[0]?.parcours?.title || 'N/A',
       p.module.title,
       p.completedAt.toLocaleDateString('fr-FR'),
     ])
@@ -146,7 +149,10 @@ async function exportQuizResults(): Promise<string> {
           module: {
             select: {
               title: true,
-              parcours: { select: { title: true } },
+              parcoursModules: {
+                select: { parcours: { select: { title: true } } },
+                take: 1,
+              },
             },
           },
         },
@@ -170,7 +176,7 @@ async function exportQuizResults(): Promise<string> {
     csvRow([
       r.progress.user.name,
       r.progress.user.email,
-      r.progress.module.parcours?.title || 'N/A',
+      r.progress.module.parcoursModules[0]?.parcours?.title || 'N/A',
       r.progress.module.title,
       r.score,
       r.totalQuestions,

--- a/app/api/admin/modules/[id]/route.ts
+++ b/app/api/admin/modules/[id]/route.ts
@@ -10,8 +10,7 @@ import { logActivity } from '@/lib/services/activity-log.service'
 const updateModuleSchema = z.object({
   title: z.string().min(1, 'Le titre est requis').optional(),
   content: z.string().min(1, 'Le contenu est requis').optional(),
-  parcoursId: z.string().uuid('ID de parcours invalide').optional(),
-  order: z.number().int().min(0).optional(),
+  parcoursIds: z.array(z.string().uuid()).optional(),
   minDuration: z.number().int().min(0).max(480).optional(),
   published: z.boolean().optional(),
 })
@@ -55,22 +54,24 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       targetType: 'module',
     })
 
-    // Notify assigned learners (fire-and-forget)
-    if (module.parcours) {
-      const parcoursId = module.parcours.id
-      prisma.userParcours.findMany({
-        where: { parcoursId },
-        include: { user: { select: { email: true } } },
-      }).then((assignments) => {
-        const emails = assignments.map((a) => a.user.email)
-        if (emails.length > 0) {
-          sendContentUpdateEmailBulk(emails, {
-            contentType: 'module',
-            contentTitle: module.title,
-            parcoursTitle: module.parcours!.title,
-          })
-        }
-      }).catch(() => { /* email errors should not block */ })
+    // Notify assigned learners for each parcours this module belongs to (fire-and-forget)
+    if (module.parcoursModules && module.parcoursModules.length > 0) {
+      for (const pm of module.parcoursModules) {
+        const parcoursId = pm.parcours.id
+        prisma.userParcours.findMany({
+          where: { parcoursId },
+          include: { user: { select: { email: true } } },
+        }).then((assignments) => {
+          const emails = assignments.map((a) => a.user.email)
+          if (emails.length > 0) {
+            sendContentUpdateEmailBulk(emails, {
+              contentType: 'module',
+              contentTitle: module.title,
+              parcoursTitle: pm.parcours.title,
+            })
+          }
+        }).catch(() => { /* email errors should not block */ })
+      }
     }
 
     return NextResponse.json(module)

--- a/app/api/admin/modules/route.ts
+++ b/app/api/admin/modules/route.ts
@@ -8,8 +8,7 @@ import { logActivity } from '@/lib/services/activity-log.service'
 const createModuleSchema = z.object({
   title: z.string().min(1, 'Le titre est requis'),
   content: z.string().min(1, 'Le contenu est requis'),
-  parcoursId: z.string().uuid('ID de parcours invalide'),
-  order: z.number().int().min(0).optional(),
+  parcoursIds: z.array(z.string().uuid()).min(1, 'Au moins un parcours requis'),
   minDuration: z.number().int().min(0).max(480).optional().default(0),
   published: z.boolean().optional().default(false),
 })
@@ -20,6 +19,27 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url)
     const parcoursId = searchParams.get('parcoursId') || undefined
+    const all = searchParams.get('all') === 'true'
+
+    if (all) {
+      // Return all modules with their parcours names (for AddExistingModuleDialog)
+      const { prisma } = await import('@/lib/db')
+      const modules = await prisma.module.findMany({
+        include: {
+          parcoursModules: {
+            include: { parcours: { select: { title: true } } },
+          },
+        },
+        orderBy: { title: 'asc' },
+      })
+      return NextResponse.json(
+        modules.map((m) => ({
+          id: m.id,
+          title: m.title,
+          parcours: m.parcoursModules.map((pm) => pm.parcours.title),
+        }))
+      )
+    }
 
     const modules = await getModules(parcoursId)
 

--- a/app/api/admin/parcours/[id]/modules/route.ts
+++ b/app/api/admin/parcours/[id]/modules/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAuth } from '@/lib/auth/require-auth'
+import { handleApiError, ApiError } from '@/lib/errors/api-error'
+import { logActivity } from '@/lib/services/activity-log.service'
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth('ADMIN')
+    const { id: parcoursId } = await params
+    const { moduleId } = await request.json()
+
+    if (!moduleId) {
+      throw new ApiError(400, 'moduleId requis', 'MISSING_MODULE_ID')
+    }
+
+    // Vérifier que le parcours existe
+    const parcours = await prisma.parcours.findUnique({
+      where: { id: parcoursId },
+    })
+    if (!parcours) {
+      throw new ApiError(404, 'Parcours non trouvé', 'PARCOURS_NOT_FOUND')
+    }
+
+    // Vérifier que le module existe
+    const module = await prisma.module.findUnique({
+      where: { id: moduleId },
+    })
+    if (!module) {
+      throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
+    }
+
+    // Vérifier qu'il n'est pas déjà dans ce parcours
+    const existing = await prisma.parcoursModule.findUnique({
+      where: { parcoursId_moduleId: { parcoursId, moduleId } },
+    })
+    if (existing) {
+      throw new ApiError(409, 'Ce module est déjà dans ce parcours', 'ALREADY_EXISTS')
+    }
+
+    // Trouver le prochain ordre
+    const maxOrder = await prisma.parcoursModule.aggregate({
+      where: { parcoursId },
+      _max: { order: true },
+    })
+    const nextOrder = (maxOrder._max.order ?? -1) + 1
+
+    // Créer le lien
+    await prisma.parcoursModule.create({
+      data: {
+        parcoursId,
+        moduleId,
+        order: nextOrder,
+      },
+    })
+
+    logActivity({
+      action: 'MODULE_CREATED',
+      userId: session.user.id,
+      targetId: moduleId,
+      targetType: 'module',
+      details: `Module "${module.title}" ajouté au parcours "${parcours.title}"`,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
             parcours: {
               select: {
                 title: true,
-                modules: { select: { id: true } },
+                parcoursModules: { select: { moduleId: true } },
               },
             },
           },
@@ -66,8 +66,8 @@ export async function GET(request: NextRequest) {
       const completedModuleIds = new Set(learner.progress.map((p) => p.moduleId))
 
       const unfinishedParcours = learner.userParcours.find((up) => {
-        const totalModules = up.parcours.modules.length
-        const completed = up.parcours.modules.filter((m) => completedModuleIds.has(m.id)).length
+        const totalModules = up.parcours.parcoursModules.length
+        const completed = up.parcours.parcoursModules.filter((pm) => completedModuleIds.has(pm.moduleId)).length
         return totalModules > 0 && completed < totalModules
       })
 
@@ -77,9 +77,9 @@ export async function GET(request: NextRequest) {
         continue
       }
 
-      const totalModules = unfinishedParcours.parcours.modules.length
-      const completedInParcours = unfinishedParcours.parcours.modules.filter(
-        (m) => completedModuleIds.has(m.id)
+      const totalModules = unfinishedParcours.parcours.parcoursModules.length
+      const completedInParcours = unfinishedParcours.parcours.parcoursModules.filter(
+        (pm) => completedModuleIds.has(pm.moduleId)
       ).length
 
       // Calculer les jours depuis la dernière activité

--- a/components/admin/AddExistingModuleDialog.tsx
+++ b/components/admin/AddExistingModuleDialog.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { BookOpen, Plus, Search, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+interface AvailableModule {
+  id: string
+  title: string
+  parcours: string[]
+}
+
+interface AddExistingModuleDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  parcoursId: string
+  excludeModuleIds: string[]
+  onAdded: () => void
+}
+
+export function AddExistingModuleDialog({
+  open,
+  onOpenChange,
+  parcoursId,
+  excludeModuleIds,
+  onAdded,
+}: AddExistingModuleDialogProps) {
+  const [modules, setModules] = useState<AvailableModule[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [search, setSearch] = useState('')
+  const [addingId, setAddingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    async function fetchModules() {
+      setIsLoading(true)
+      try {
+        const res = await fetch('/api/admin/modules?all=true')
+        if (res.ok) {
+          const data = await res.json()
+          setModules(data.filter((m: AvailableModule) => !excludeModuleIds.includes(m.id)))
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchModules()
+  }, [open, excludeModuleIds])
+
+  const filtered = modules.filter((m) =>
+    m.title.toLowerCase().includes(search.toLowerCase())
+  )
+
+  async function handleAdd(moduleId: string) {
+    setAddingId(moduleId)
+    try {
+      const res = await fetch(`/api/admin/parcours/${parcoursId}/modules`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ moduleId }),
+      })
+
+      if (res.ok) {
+        toast.success('Module ajouté au parcours')
+        setModules((prev) => prev.filter((m) => m.id !== moduleId))
+        onAdded()
+      } else {
+        const data = await res.json()
+        toast.error(data.error || 'Erreur lors de l\'ajout')
+      }
+    } catch {
+      toast.error('Erreur lors de l\'ajout')
+    } finally {
+      setAddingId(null)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <BookOpen className="h-5 w-5 text-primary" />
+            Ajouter un module existant
+          </DialogTitle>
+          <DialogDescription>
+            Sélectionnez un module déjà créé pour l&apos;ajouter à ce parcours.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Rechercher un module..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="max-h-80 overflow-y-auto space-y-2">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground py-8">
+              {modules.length === 0
+                ? 'Tous les modules sont déjà dans ce parcours'
+                : 'Aucun module trouvé'}
+            </p>
+          ) : (
+            filtered.map((module) => (
+              <div
+                key={module.id}
+                className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm truncate">{module.title}</p>
+                  {module.parcours.length > 0 && (
+                    <div className="flex gap-1 mt-1 flex-wrap">
+                      {module.parcours.map((p, i) => (
+                        <Badge key={i} variant="secondary" className="text-[10px]">
+                          {p}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleAdd(module.id)}
+                  disabled={addingId === module.id}
+                >
+                  {addingId === module.id ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <>
+                      <Plus className="h-3.5 w-3.5 mr-1" />
+                      Ajouter
+                    </>
+                  )}
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/EditModulePageClient.tsx
+++ b/components/admin/EditModulePageClient.tsx
@@ -9,13 +9,11 @@ interface Module {
   id: string
   title: string
   content: string
-  order: number
   minDuration: number
   published: boolean
-  parcours: {
-    id: string
-    title: string
-  }
+  parcoursModules: {
+    parcours: { id: string; title: string }
+  }[]
 }
 
 interface Parcours {
@@ -81,7 +79,7 @@ export function EditModulePageClient({ moduleId }: EditModulePageClientProps) {
     <div className="space-y-6">
       <PageBreadcrumb items={[
         { label: 'Modules', href: '/admin/modules' },
-        { label: module.parcours.title, href: `/admin/parcours/${module.parcours.id}` },
+        ...(module.parcoursModules.length > 0 ? [{ label: module.parcoursModules[0].parcours.title, href: `/admin/parcours/${module.parcoursModules[0].parcours.id}` }] : []),
         { label: `Modifier : ${module.title}` },
       ]} />
 
@@ -97,8 +95,7 @@ export function EditModulePageClient({ moduleId }: EditModulePageClientProps) {
           id: module.id,
           title: module.title,
           content: module.content,
-          parcoursId: module.parcours.id,
-          order: module.order,
+          parcoursIds: module.parcoursModules.map((pm) => pm.parcours.id),
           minDuration: module.minDuration,
           published: module.published,
         }}

--- a/components/admin/ModuleForm.tsx
+++ b/components/admin/ModuleForm.tsx
@@ -6,13 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Loader2, ExternalLink, Eye, Code, AlertCircle, ImageIcon, Video, Clock, Globe } from 'lucide-react'
@@ -30,23 +24,25 @@ interface ModuleFormProps {
     id: string
     title: string
     content: string
-    parcoursId: string
-    order: number
+    parcoursIds: string[]
     minDuration?: number
     published?: boolean
   }
   parcoursList: Parcours[]
+  /** Pre-select a parcours when creating from a parcours detail page */
+  defaultParcoursId?: string
 }
 
-export function ModuleForm({ module, parcoursList }: ModuleFormProps) {
+export function ModuleForm({ module, parcoursList, defaultParcoursId }: ModuleFormProps) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const [title, setTitle] = useState(module?.title || '')
   const [content, setContent] = useState(module?.content || '')
-  const [parcoursId, setParcoursId] = useState(module?.parcoursId || '')
-  const [order, setOrder] = useState(module?.order?.toString() || '0')
+  const [selectedParcoursIds, setSelectedParcoursIds] = useState<string[]>(
+    module?.parcoursIds || (defaultParcoursId ? [defaultParcoursId] : [])
+  )
   const [minDuration, setMinDuration] = useState(module?.minDuration?.toString() || '0')
   const [published, setPublished] = useState(module?.published ?? false)
 
@@ -87,8 +83,7 @@ export function ModuleForm({ module, parcoursList }: ModuleFormProps) {
         body: JSON.stringify({
           title,
           content,
-          parcoursId,
-          order: parseInt(order, 10),
+          parcoursIds: selectedParcoursIds,
           minDuration: parseInt(minDuration, 10) || 0,
           published,
         }),
@@ -159,34 +154,34 @@ export function ModuleForm({ module, parcoursList }: ModuleFormProps) {
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="parcours">Parcours *</Label>
-              <Select value={parcoursId} onValueChange={setParcoursId} required>
-                <SelectTrigger>
-                  <SelectValue placeholder="Sélectionnez un parcours" />
-                </SelectTrigger>
-                <SelectContent>
-                  {parcoursList.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.title}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+          <div className="space-y-2">
+            <Label>Parcours *</Label>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 rounded-lg border p-3 max-h-40 overflow-y-auto">
+              {parcoursList.map((p) => (
+                <label
+                  key={p.id}
+                  className="flex items-center gap-2 cursor-pointer hover:bg-muted/50 rounded px-2 py-1.5 transition-colors"
+                >
+                  <Checkbox
+                    checked={selectedParcoursIds.includes(p.id)}
+                    onCheckedChange={(checked) => {
+                      setSelectedParcoursIds((prev) =>
+                        checked
+                          ? [...prev, p.id]
+                          : prev.filter((id) => id !== p.id)
+                      )
+                    }}
+                  />
+                  <span className="text-sm truncate">{p.title}</span>
+                </label>
+              ))}
             </div>
+            {selectedParcoursIds.length === 0 && (
+              <p className="text-xs text-muted-foreground">Sélectionnez au moins un parcours</p>
+            )}
+          </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="order">Ordre</Label>
-              <Input
-                id="order"
-                type="number"
-                min="0"
-                value={order}
-                onChange={(e) => setOrder(e.target.value)}
-              />
-            </div>
-
+          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="minDuration" className="flex items-center gap-1.5">
                 <Clock className="h-3.5 w-3.5" />
@@ -405,7 +400,7 @@ Description de la section..."
         >
           Annuler
         </Button>
-        <Button type="submit" disabled={isSubmitting || !title || !content || !parcoursId}>
+        <Button type="submit" disabled={isSubmitting || !title || !content || selectedParcoursIds.length === 0}>
           {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {isEditing ? 'Mettre à jour' : 'Créer le module'}
         </Button>

--- a/components/admin/ModulePreviewClient.tsx
+++ b/components/admin/ModulePreviewClient.tsx
@@ -15,11 +15,11 @@ interface Module {
   id: string
   title: string
   content: string
-  order: number
-  parcours: {
-    id: string
-    title: string
-  }
+  parcoursModules: {
+    parcoursId: string
+    order: number
+    parcours: { id: string; title: string }
+  }[]
 }
 
 interface ModulePreviewClientProps {
@@ -98,7 +98,7 @@ export function ModulePreviewClient({ moduleId }: ModulePreviewClientProps) {
       <div className="flex items-center justify-between">
         <PageBreadcrumb items={[
           { label: 'Modules', href: '/admin/modules' },
-          { label: module.parcours.title, href: `/admin/parcours/${module.parcours.id}` },
+          ...(module.parcoursModules.length > 0 ? [{ label: module.parcoursModules[0].parcours.title, href: `/admin/parcours/${module.parcoursModules[0].parcoursId}` }] : []),
           { label: module.title },
         ]} />
         <Button variant="outline" size="sm" asChild>
@@ -112,10 +112,13 @@ export function ModulePreviewClient({ moduleId }: ModulePreviewClientProps) {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Prévisualisation du module</h1>
         <div className="flex items-center gap-2 mt-1">
-          <Badge variant="secondary">{module.parcours.title}</Badge>
-          <span className="text-sm text-muted-foreground">
-            Module {module.order + 1}
-          </span>
+          {module.parcoursModules.length > 0 ? (
+            module.parcoursModules.map((pm) => (
+              <Badge key={pm.parcoursId} variant="secondary">{pm.parcours.title}</Badge>
+            ))
+          ) : (
+            <Badge variant="outline">Non assigné</Badge>
+          )}
         </div>
       </div>
 

--- a/components/admin/ModulesPageClient.tsx
+++ b/components/admin/ModulesPageClient.tsx
@@ -20,11 +20,12 @@ import { toast } from 'sonner'
 interface Module {
   id: string
   title: string
-  order: number
-  parcours: {
-    id: string
-    title: string
-  }
+  published?: boolean
+  parcoursModules: {
+    parcoursId: string
+    order: number
+    parcours: { id: string; title: string }
+  }[]
   hasQuiz: boolean
   updatedAt: Date
 }
@@ -90,7 +91,7 @@ export function ModulesPageClient() {
 
   const filteredModules = selectedParcours === 'all'
     ? modules
-    : modules.filter((m) => m.parcours.id === selectedParcours)
+    : modules.filter((m) => m.parcoursModules.some((pm) => pm.parcoursId === selectedParcours))
 
   const moduleToDelete = modules.find((m) => m.id === deleteId)
 
@@ -160,8 +161,8 @@ export function ModulesPageClient() {
               key={m.id}
               id={m.id}
               title={m.title}
-              order={m.order}
-              parcoursTitle={m.parcours.title}
+              parcoursTitles={m.parcoursModules.map((pm) => pm.parcours.title)}
+              published={m.published}
               hasQuiz={m.hasQuiz}
               updatedAt={m.updatedAt}
               previewHref={`/admin/modules/${m.id}/preview`}

--- a/components/admin/ModulesTable.tsx
+++ b/components/admin/ModulesTable.tsx
@@ -18,12 +18,12 @@ import { Edit, Trash2, GripVertical, Eye } from 'lucide-react'
 interface Module {
   id: string
   title: string
-  order: number
   published?: boolean
-  parcours: {
-    id: string
-    title: string
-  }
+  parcoursModules: {
+    parcoursId: string
+    order: number
+    parcours: { id: string; title: string }
+  }[]
   hasQuiz: boolean
   updatedAt: Date
 }
@@ -77,7 +77,7 @@ export function ModulesTable({ modules, onDelete }: ModulesTableProps) {
                 <TableCell>
                   <div className="flex items-center gap-2">
                     <GripVertical className="h-4 w-4 text-muted-foreground cursor-grab" />
-                    {module.order + 1}
+                    {(module.parcoursModules[0]?.order ?? 0) + 1}
                   </div>
                 </TableCell>
                 <TableCell className="font-medium">
@@ -91,7 +91,13 @@ export function ModulesTable({ modules, onDelete }: ModulesTableProps) {
                   </div>
                 </TableCell>
                 <TableCell>
-                  <Badge variant="secondary">{module.parcours.title}</Badge>
+                  {module.parcoursModules.length > 0 ? (
+                    module.parcoursModules.map((pm) => (
+                      <Badge key={pm.parcoursId} variant="secondary" className="mr-1">{pm.parcours.title}</Badge>
+                    ))
+                  ) : (
+                    <Badge variant="outline">Non assigné</Badge>
+                  )}
                 </TableCell>
                 <TableCell>
                   {module.hasQuiz ? (

--- a/components/admin/ParcoursDetailClient.tsx
+++ b/components/admin/ParcoursDetailClient.tsx
@@ -7,8 +7,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { ParcoursDetailSkeleton } from '@/components/shared/ParcoursCard'
 import { PageBreadcrumb } from '@/components/shared/PageBreadcrumb'
-import { BookOpen, Plus, Edit, Eye, Trash2 } from 'lucide-react'
+import { BookOpen, Plus, Link2, Edit, Eye, Trash2 } from 'lucide-react'
 import { ConfirmDialog } from './ConfirmDialog'
+import { AddExistingModuleDialog } from './AddExistingModuleDialog'
 import { toast } from 'sonner'
 import { SortableList } from '@/components/shared/SortableList'
 
@@ -38,6 +39,7 @@ export function ParcoursDetailClient({ parcoursId }: ParcoursDetailClientProps) 
   const [error, setError] = useState<string | null>(null)
   const [deleteModuleId, setDeleteModuleId] = useState<string | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [showAddExisting, setShowAddExisting] = useState(false)
 
   useEffect(() => {
     async function fetchParcours() {
@@ -167,12 +169,18 @@ export function ParcoursDetailClient({ parcoursId }: ParcoursDetailClientProps) 
                 Modules ordonnés par position
               </CardDescription>
             </div>
-            <Button asChild>
-              <Link href={`/admin/modules/new?parcoursId=${parcours.id}`}>
-                <Plus className="mr-2 h-4 w-4" />
-                Ajouter un module
-              </Link>
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setShowAddExisting(true)}>
+                <Link2 className="mr-2 h-4 w-4" />
+                Module existant
+              </Button>
+              <Button asChild>
+                <Link href={`/admin/modules/new?parcoursId=${parcours.id}`}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Nouveau module
+                </Link>
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -231,6 +239,18 @@ export function ParcoursDetailClient({ parcoursId }: ParcoursDetailClientProps) 
         onConfirm={handleDeleteModule}
         isLoading={isDeleting}
         variant="destructive"
+      />
+
+      <AddExistingModuleDialog
+        open={showAddExisting}
+        onOpenChange={setShowAddExisting}
+        parcoursId={parcours.id}
+        excludeModuleIds={parcours.modules.map((m) => m.id)}
+        onAdded={async () => {
+          // Refresh parcours data
+          const res = await fetch(`/api/admin/parcours/${parcoursId}`)
+          if (res.ok) setParcours(await res.json())
+        }}
       />
     </div>
   )

--- a/components/shared/ModuleCard.tsx
+++ b/components/shared/ModuleCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -10,9 +10,9 @@ import { BookOpen, Route, Eye, Edit, Trash2, FileQuestion } from 'lucide-react'
 interface ModuleCardProps {
   id: string
   title: string
-  order: number
-  parcoursTitle: string
+  parcoursTitles: string[]
   hasQuiz?: boolean
+  published?: boolean
   updatedAt?: Date | string
   previewHref: string
   editHref?: string
@@ -21,36 +21,55 @@ interface ModuleCardProps {
 
 export function ModuleCard({
   title,
-  order,
-  parcoursTitle,
+  parcoursTitles,
   hasQuiz,
+  published,
   updatedAt,
   previewHref,
   editHref,
   onDelete,
 }: ModuleCardProps) {
   return (
-    <Card className="hover:shadow-md transition-all hover:border-gray-300">
-      <CardHeader>
+    <Card className="hover:shadow-md transition-all hover:border-gray-300 dark:hover:border-gray-600">
+      <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-3">
-          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-emerald-50 shrink-0">
-            <BookOpen className="h-4.5 w-4.5 text-emerald-600" />
+          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-emerald-50 dark:bg-emerald-950 shrink-0">
+            <BookOpen className="h-4.5 w-4.5 text-emerald-600 dark:text-emerald-400" />
           </div>
-          <span className="truncate">{title}</span>
+          <div className="flex-1 min-w-0">
+            <span className="truncate block">{title}</span>
+            {published === false && (
+              <Badge variant="outline" className="mt-1 text-[10px] text-orange-600 border-orange-300">
+                Brouillon
+              </Badge>
+            )}
+          </div>
         </CardTitle>
-        <CardDescription className="flex items-center gap-2 flex-wrap">
-          <Badge variant="secondary" className="gap-1">
-            <Route className="h-3 w-3" />
-            {parcoursTitle}
-          </Badge>
-          <span className="text-xs">Module {order + 1}</span>
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {parcoursTitles.length > 0 ? (
+            <>
+              {parcoursTitles.slice(0, 2).map((t, i) => (
+                <Badge key={i} variant="secondary" className="gap-1 text-xs max-w-[140px] truncate">
+                  <Route className="h-3 w-3 shrink-0" />
+                  {t}
+                </Badge>
+              ))}
+              {parcoursTitles.length > 2 && (
+                <Badge variant="outline" className="text-xs" title={parcoursTitles.slice(2).join(', ')}>
+                  +{parcoursTitles.length - 2}
+                </Badge>
+              )}
+            </>
+          ) : (
+            <Badge variant="outline" className="text-xs text-muted-foreground">Non assigné</Badge>
+          )}
           {hasQuiz !== undefined && (
-            <Badge variant={hasQuiz ? 'default' : 'outline'} className="gap-1">
+            <Badge variant={hasQuiz ? 'default' : 'outline'} className="gap-1 text-xs">
               <FileQuestion className="h-3 w-3" />
-              Quiz {hasQuiz ? 'oui' : 'non'}
+              {hasQuiz ? 'Quiz' : 'Sans quiz'}
             </Badge>
           )}
-        </CardDescription>
+        </div>
       </CardHeader>
       <CardContent>
         {updatedAt && (

--- a/components/trainer/TrainerModuleViewClient.tsx
+++ b/components/trainer/TrainerModuleViewClient.tsx
@@ -15,7 +15,7 @@ interface Module {
   parcours: {
     id: string
     title: string
-  }
+  } | null
 }
 
 interface TrainerModuleViewClientProps {
@@ -73,14 +73,18 @@ export function TrainerModuleViewClient({ parcoursId, moduleId }: TrainerModuleV
     <div className="space-y-6">
       <PageBreadcrumb items={[
         { label: 'Parcours', href: '/trainer/parcours' },
-        { label: module.parcours.title, href: `/trainer/parcours/${parcoursId}` },
+        ...(module.parcours ? [{ label: module.parcours.title, href: `/trainer/parcours/${parcoursId}` }] : []),
         { label: module.title },
       ]} />
 
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{module.title}</h1>
         <div className="flex items-center gap-2 mt-1">
-          <Badge variant="secondary">{module.parcours.title}</Badge>
+          {module.parcours ? (
+            <Badge variant="secondary">{module.parcours.title}</Badge>
+          ) : (
+            <Badge variant="outline">Non assigné</Badge>
+          )}
           <span className="text-sm text-muted-foreground">
             Module {module.order + 1}
           </span>

--- a/lib/services/admin/learners.ts
+++ b/lib/services/admin/learners.ts
@@ -57,8 +57,8 @@ export async function getLearners(options?: GetLearnersOptions): Promise<Learner
             select: {
               id: true,
               title: true,
-              modules: {
-                select: { id: true },
+              parcoursModules: {
+                select: { moduleId: true },
               },
             },
           },
@@ -77,8 +77,9 @@ export async function getLearners(options?: GetLearnersOptions): Promise<Learner
     const completedModuleIds = new Set(learner.progress.map((p) => p.moduleId))
 
     const parcoursDetails: LearnerParcoursDetail[] = learner.userParcours.map((up) => {
-      const totalModules = up.parcours.modules.length
-      const completed = up.parcours.modules.filter((m) => completedModuleIds.has(m.id)).length
+      const moduleIds = up.parcours.parcoursModules.map((pm) => pm.moduleId)
+      const totalModules = moduleIds.length
+      const completed = moduleIds.filter((id) => completedModuleIds.has(id)).length
       const percentage = totalModules > 0 ? Math.round((completed / totalModules) * 100) : 0
       return {
         id: up.parcours.id,
@@ -125,11 +126,19 @@ export async function getLearnerById(id: string) {
       trainer: {
         select: { id: true, name: true, email: true },
       },
-      parcours: {
+      userParcours: {
         include: {
-          modules: {
-            orderBy: { order: 'asc' },
-            select: { id: true, title: true, order: true },
+          parcours: {
+            include: {
+              parcoursModules: {
+                orderBy: { order: 'asc' },
+                include: {
+                  module: {
+                    select: { id: true, title: true },
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/lib/services/admin/modules.ts
+++ b/lib/services/admin/modules.ts
@@ -5,13 +5,13 @@ export interface ModuleWithDetails {
   id: string
   title: string
   content: string
-  order: number
   minDuration: number
   published: boolean
-  parcours: {
-    id: string
-    title: string
-  }
+  parcoursModules: {
+    parcoursId: string
+    order: number
+    parcours: { id: string; title: string }
+  }[]
   hasQuiz: boolean
   createdAt: Date
   updatedAt: Date
@@ -20,8 +20,7 @@ export interface ModuleWithDetails {
 export interface CreateModuleInput {
   title: string
   content: string
-  parcoursId: string
-  order?: number
+  parcoursIds: string[]
   minDuration?: number
   published?: boolean
 }
@@ -29,35 +28,65 @@ export interface CreateModuleInput {
 export interface UpdateModuleInput {
   title?: string
   content?: string
-  parcoursId?: string
-  order?: number
+  parcoursIds?: string[]
   minDuration?: number
   published?: boolean
 }
 
 export async function getModules(parcoursId?: string): Promise<ModuleWithDetails[]> {
-  const where = parcoursId ? { parcoursId } : {}
+  if (parcoursId) {
+    // Query via ParcoursModule pivot to get modules for a specific parcours
+    const parcoursModules = await prisma.parcoursModule.findMany({
+      where: { parcoursId },
+      orderBy: { order: 'asc' },
+      include: {
+        module: {
+          include: {
+            quiz: { select: { id: true } },
+          },
+        },
+        parcours: { select: { id: true, title: true } },
+      },
+    })
+
+    return parcoursModules.map((pm) => ({
+      id: pm.module.id,
+      title: pm.module.title,
+      content: pm.module.content,
+      minDuration: pm.module.minDuration,
+      published: pm.module.published,
+      parcoursModules: [{ parcoursId: pm.parcoursId, order: pm.order, parcours: pm.parcours }],
+      hasQuiz: !!pm.module.quiz,
+      createdAt: pm.module.createdAt,
+      updatedAt: pm.module.updatedAt,
+    }))
+  }
+
+  // No parcoursId filter — return all modules
   const modules = await prisma.module.findMany({
-    where,
     include: {
-      parcours: {
-        select: { id: true, title: true },
+      parcoursModules: {
+        include: {
+          parcours: { select: { id: true, title: true } },
+        },
+        orderBy: { order: 'asc' },
       },
-      quiz: {
-        select: { id: true },
-      },
+      quiz: { select: { id: true } },
     },
-    orderBy: { order: 'asc' },
+    orderBy: { createdAt: 'asc' },
   })
 
   return modules.map((m) => ({
     id: m.id,
     title: m.title,
     content: m.content,
-    order: m.order,
     minDuration: m.minDuration,
     published: m.published,
-    parcours: m.parcours,
+    parcoursModules: m.parcoursModules.map((pm) => ({
+      parcoursId: pm.parcoursId,
+      order: pm.order,
+      parcours: pm.parcours,
+    })),
     hasQuiz: !!m.quiz,
     createdAt: m.createdAt,
     updatedAt: m.updatedAt,
@@ -68,12 +97,13 @@ export async function getModuleById(id: string): Promise<ModuleWithDetails | nul
   const module = await prisma.module.findUnique({
     where: { id },
     include: {
-      parcours: {
-        select: { id: true, title: true },
+      parcoursModules: {
+        include: {
+          parcours: { select: { id: true, title: true } },
+        },
+        orderBy: { order: 'asc' },
       },
-      quiz: {
-        select: { id: true },
-      },
+      quiz: { select: { id: true } },
     },
   })
 
@@ -83,10 +113,9 @@ export async function getModuleById(id: string): Promise<ModuleWithDetails | nul
     id: module.id,
     title: module.title,
     content: module.content,
-    order: module.order,
     minDuration: module.minDuration,
     published: module.published,
-    parcours: module.parcours,
+    parcoursModules: module.parcoursModules,
     hasQuiz: !!module.quiz,
     createdAt: module.createdAt,
     updatedAt: module.updatedAt,
@@ -94,35 +123,43 @@ export async function getModuleById(id: string): Promise<ModuleWithDetails | nul
 }
 
 export async function createModule(input: CreateModuleInput) {
-  const parcours = await prisma.parcours.findUnique({
-    where: { id: input.parcoursId },
+  // Validate all parcours exist
+  const parcoursCount = await prisma.parcours.count({
+    where: { id: { in: input.parcoursIds } },
   })
-
-  if (!parcours) {
-    throw new ApiError(404, 'Parcours non trouvé', 'PARCOURS_NOT_FOUND')
+  if (parcoursCount !== input.parcoursIds.length) {
+    throw new ApiError(404, 'Un ou plusieurs parcours non trouvés', 'PARCOURS_NOT_FOUND')
   }
 
-  let order = input.order
-  if (order === undefined) {
-    const maxOrder = await prisma.module.aggregate({
-      where: { parcoursId: input.parcoursId },
+  // Get max order for each parcours
+  const orderPromises = input.parcoursIds.map(async (parcoursId) => {
+    const maxOrder = await prisma.parcoursModule.aggregate({
+      where: { parcoursId },
       _max: { order: true },
     })
-    order = (maxOrder._max.order ?? -1) + 1
-  }
+    return { parcoursId, order: (maxOrder._max.order ?? -1) + 1 }
+  })
+  const orders = await Promise.all(orderPromises)
 
+  // Create the module and link it to all parcours
   const module = await prisma.module.create({
     data: {
       title: input.title,
       content: input.content,
-      parcoursId: input.parcoursId,
-      order,
       minDuration: input.minDuration ?? 0,
       published: input.published ?? false,
+      parcoursModules: {
+        create: orders.map((o) => ({
+          parcoursId: o.parcoursId,
+          order: o.order,
+        })),
+      },
     },
     include: {
-      parcours: {
-        select: { id: true, title: true },
+      parcoursModules: {
+        include: {
+          parcours: { select: { id: true, title: true } },
+        },
       },
     },
   })
@@ -133,18 +170,41 @@ export async function createModule(input: CreateModuleInput) {
 export async function updateModule(id: string, input: UpdateModuleInput) {
   const existing = await prisma.module.findUnique({
     where: { id },
+    include: {
+      parcoursModules: { select: { parcoursId: true } },
+    },
   })
 
   if (!existing) {
     throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
   }
 
-  if (input.parcoursId && input.parcoursId !== existing.parcoursId) {
-    const parcours = await prisma.parcours.findUnique({
-      where: { id: input.parcoursId },
-    })
-    if (!parcours) {
-      throw new ApiError(404, 'Parcours non trouvé', 'PARCOURS_NOT_FOUND')
+  // Sync parcours associations if parcoursIds provided
+  if (input.parcoursIds) {
+    const currentIds = existing.parcoursModules.map((pm) => pm.parcoursId)
+    const toAdd = input.parcoursIds.filter((id) => !currentIds.includes(id))
+    const toRemove = currentIds.filter((id) => !input.parcoursIds!.includes(id))
+
+    // Remove unlinked parcours
+    if (toRemove.length > 0) {
+      await prisma.parcoursModule.deleteMany({
+        where: { moduleId: id, parcoursId: { in: toRemove } },
+      })
+    }
+
+    // Add new parcours links
+    for (const parcoursId of toAdd) {
+      const maxOrder = await prisma.parcoursModule.aggregate({
+        where: { parcoursId },
+        _max: { order: true },
+      })
+      await prisma.parcoursModule.create({
+        data: {
+          moduleId: id,
+          parcoursId,
+          order: (maxOrder._max.order ?? -1) + 1,
+        },
+      })
     }
   }
 
@@ -153,14 +213,14 @@ export async function updateModule(id: string, input: UpdateModuleInput) {
     data: {
       ...(input.title !== undefined && { title: input.title }),
       ...(input.content !== undefined && { content: input.content }),
-      ...(input.parcoursId !== undefined && { parcoursId: input.parcoursId }),
-      ...(input.order !== undefined && { order: input.order }),
       ...(input.minDuration !== undefined && { minDuration: input.minDuration }),
       ...(input.published !== undefined && { published: input.published }),
     },
     include: {
-      parcours: {
-        select: { id: true, title: true },
+      parcoursModules: {
+        include: {
+          parcours: { select: { id: true, title: true } },
+        },
       },
     },
   })
@@ -176,6 +236,10 @@ export async function deleteModule(id: string) {
   if (!existing) {
     throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
   }
+
+  // ParcoursModule records will be cascade-deleted if configured,
+  // otherwise delete them explicitly first
+  await prisma.parcoursModule.deleteMany({ where: { moduleId: id } })
 
   await prisma.module.delete({
     where: { id },
@@ -196,8 +260,8 @@ export async function reorderModules(
 
   await prisma.$transaction(
     moduleOrders.map(({ id, order }) =>
-      prisma.module.update({
-        where: { id, parcoursId },
+      prisma.parcoursModule.updateMany({
+        where: { moduleId: id, parcoursId },
         data: { order },
       })
     )

--- a/lib/services/admin/parcours.ts
+++ b/lib/services/admin/parcours.ts
@@ -26,7 +26,7 @@ export async function getParcours(): Promise<ParcoursWithStats[]> {
     include: {
       _count: {
         select: {
-          modules: true,
+          parcoursModules: true,
           userParcours: true,
         },
       },
@@ -38,7 +38,7 @@ export async function getParcours(): Promise<ParcoursWithStats[]> {
     id: p.id,
     title: p.title,
     description: p.description,
-    moduleCount: p._count.modules,
+    moduleCount: p._count.parcoursModules,
     learnerCount: p._count.userParcours,
     createdAt: p.createdAt,
     updatedAt: p.updatedAt,
@@ -49,13 +49,16 @@ export async function getParcoursById(id: string) {
   const parcours = await prisma.parcours.findUnique({
     where: { id },
     include: {
-      modules: {
+      parcoursModules: {
         orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          title: true,
-          order: true,
-          createdAt: true,
+        include: {
+          module: {
+            select: {
+              id: true,
+              title: true,
+              createdAt: true,
+            },
+          },
         },
       },
       _count: {
@@ -70,6 +73,13 @@ export async function getParcoursById(id: string) {
 
   return {
     ...parcours,
+    // Flatten parcoursModules into a modules array for backward compatibility
+    modules: parcours.parcoursModules.map((pm) => ({
+      id: pm.module.id,
+      title: pm.module.title,
+      order: pm.order,
+      createdAt: pm.module.createdAt,
+    })),
     learnerCount: parcours._count.userParcours,
   }
 }

--- a/lib/services/badge.service.ts
+++ b/lib/services/badge.service.ts
@@ -36,14 +36,19 @@ export async function checkAndAwardBadges(userId: string): Promise<BadgeType[]> 
   // Calculate completed parcours
   let completedParcours = 0
   for (const assignment of assignments) {
-    const totalModules = await prisma.module.count({
+    const totalModules = await prisma.parcoursModule.count({
       where: { parcoursId: assignment.parcoursId },
     })
     if (totalModules === 0) continue
+    const parcoursModuleIds = await prisma.parcoursModule.findMany({
+      where: { parcoursId: assignment.parcoursId },
+      select: { moduleId: true },
+    })
+    const moduleIds = parcoursModuleIds.map((pm) => pm.moduleId)
     const completedInParcours = await prisma.progress.count({
       where: {
         userId,
-        module: { parcoursId: assignment.parcoursId },
+        moduleId: { in: moduleIds },
       },
     })
     if (completedInParcours >= totalModules) {

--- a/lib/services/certificate.service.ts
+++ b/lib/services/certificate.service.ts
@@ -30,18 +30,25 @@ async function resolveParcoursId(userId: string, parcoursId?: string): Promise<s
   return user?.parcoursId || null
 }
 
+/** Get the module IDs belonging to a parcours via ParcoursModule */
+async function getParcoursModuleIds(parcoursId: string): Promise<string[]> {
+  const pms = await prisma.parcoursModule.findMany({
+    where: { parcoursId },
+    select: { moduleId: true },
+  })
+  return pms.map((pm) => pm.moduleId)
+}
+
 export async function canGenerateCertificate(userId: string, parcoursId?: string): Promise<boolean> {
   const targetParcoursId = await resolveParcoursId(userId, parcoursId)
   if (!targetParcoursId) return false
 
-  const [completedCount, totalCount] = await Promise.all([
-    prisma.progress.count({
-      where: { userId, module: { parcoursId: targetParcoursId } },
-    }),
-    prisma.module.count({
-      where: { parcoursId: targetParcoursId },
-    }),
-  ])
+  const moduleIds = await getParcoursModuleIds(targetParcoursId)
+  const totalCount = moduleIds.length
+
+  const completedCount = await prisma.progress.count({
+    where: { userId, moduleId: { in: moduleIds } },
+  })
 
   return totalCount > 0 && completedCount === totalCount
 }
@@ -66,18 +73,19 @@ export async function getCertificateData(
 
   const parcours = await prisma.parcours.findUnique({
     where: { id: targetParcoursId },
-    include: { modules: { select: { id: true } } },
+    include: { parcoursModules: { select: { moduleId: true } } },
   })
 
   if (!parcours) {
     throw new ApiError(404, 'Parcours non trouvé', 'NOT_FOUND')
   }
 
-  const completedCount = await prisma.progress.count({
-    where: { userId, module: { parcoursId: targetParcoursId } },
-  })
+  const moduleIds = parcours.parcoursModules.map((pm) => pm.moduleId)
+  const totalModules = moduleIds.length
 
-  const totalModules = parcours.modules.length
+  const completedCount = await prisma.progress.count({
+    where: { userId, moduleId: { in: moduleIds } },
+  })
 
   if (completedCount < totalModules) {
     throw new ApiError(400, 'Le parcours n\'est pas encore complété', 'PARCOURS_NOT_COMPLETED')
@@ -85,17 +93,17 @@ export async function getCertificateData(
 
   const [lastProgress, firstProgress, quizResults] = await Promise.all([
     prisma.progress.findFirst({
-      where: { userId, module: { parcoursId: targetParcoursId } },
+      where: { userId, moduleId: { in: moduleIds } },
       orderBy: { completedAt: 'desc' },
       select: { completedAt: true },
     }),
     prisma.progress.findFirst({
-      where: { userId, module: { parcoursId: targetParcoursId } },
+      where: { userId, moduleId: { in: moduleIds } },
       orderBy: { completedAt: 'asc' },
       select: { completedAt: true },
     }),
     prisma.quizResult.findMany({
-      where: { progress: { userId, module: { parcoursId: targetParcoursId } } },
+      where: { progress: { userId, moduleId: { in: moduleIds } } },
       select: { score: true },
     }),
   ])

--- a/lib/services/module.service.ts
+++ b/lib/services/module.service.ts
@@ -5,8 +5,12 @@ export async function getModuleById(moduleId: string, userId: string) {
   const module = await prisma.module.findUnique({
     where: { id: moduleId },
     include: {
-      parcours: {
-        select: { id: true, title: true },
+      parcoursModules: {
+        select: {
+          parcoursId: true,
+          order: true,
+          parcours: { select: { id: true, title: true } },
+        },
       },
       quiz: {
         select: { id: true },
@@ -18,9 +22,18 @@ export async function getModuleById(moduleId: string, userId: string) {
     throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
   }
 
+  // Use first parcoursModule to determine parcours context
+  const pm = module.parcoursModules[0]
+  if (!pm) {
+    throw new ApiError(404, 'Module non associé à un parcours', 'MODULE_NOT_FOUND')
+  }
+
+  const parcoursId = pm.parcoursId
+  const moduleOrder = pm.order
+
   // Check if user has access to this module (assigned to this parcours via UserParcours)
   const hasAccess = await prisma.userParcours.findUnique({
-    where: { userId_parcoursId: { userId, parcoursId: module.parcoursId } },
+    where: { userId_parcoursId: { userId, parcoursId } },
   })
 
   // Fallback: check legacy parcoursId on User
@@ -29,7 +42,7 @@ export async function getModuleById(moduleId: string, userId: string) {
       where: { id: userId },
       select: { parcoursId: true },
     })
-    if (user?.parcoursId !== module.parcoursId) {
+    if (user?.parcoursId !== parcoursId) {
       throw new ApiError(403, 'Accès non autorisé à ce module', 'MODULE_ACCESS_DENIED')
     }
   }
@@ -41,25 +54,25 @@ export async function getModuleById(moduleId: string, userId: string) {
     },
   })
 
-  // Get adjacent modules for navigation
-  const [previousModule, nextModule] = await Promise.all([
-    prisma.module.findFirst({
+  // Get adjacent modules for navigation via ParcoursModule
+  const [previousPM, nextPM] = await Promise.all([
+    prisma.parcoursModule.findFirst({
       where: {
-        parcoursId: module.parcoursId,
-        published: true,
-        order: { lt: module.order },
+        parcoursId,
+        module: { published: true },
+        order: { lt: moduleOrder },
       },
       orderBy: { order: 'desc' },
-      select: { id: true, title: true, order: true },
+      include: { module: { select: { id: true, title: true } } },
     }),
-    prisma.module.findFirst({
+    prisma.parcoursModule.findFirst({
       where: {
-        parcoursId: module.parcoursId,
-        published: true,
-        order: { gt: module.order },
+        parcoursId,
+        module: { published: true },
+        order: { gt: moduleOrder },
       },
       orderBy: { order: 'asc' },
-      select: { id: true, title: true, order: true },
+      include: { module: { select: { id: true, title: true } } },
     }),
   ])
 
@@ -68,27 +81,36 @@ export async function getModuleById(moduleId: string, userId: string) {
       id: module.id,
       title: module.title,
       content: module.content,
-      order: module.order,
+      order: moduleOrder,
       hasQuiz: !!module.quiz,
       minDuration: module.minDuration,
     },
-    parcours: module.parcours,
+    parcours: pm.parcours,
     isCompleted: !!progress,
     navigation: {
-      previous: previousModule,
-      next: nextModule,
+      previous: previousPM ? { id: previousPM.module.id, title: previousPM.module.title, order: previousPM.order } : null,
+      next: nextPM ? { id: nextPM.module.id, title: nextPM.module.title, order: nextPM.order } : null,
     },
   }
 }
 
 export async function getModulesForParcours(parcoursId: string) {
-  return prisma.module.findMany({
-    where: { parcoursId, published: true },
+  const parcoursModules = await prisma.parcoursModule.findMany({
+    where: { parcoursId, module: { published: true } },
     orderBy: { order: 'asc' },
-    select: {
-      id: true,
-      title: true,
-      order: true,
+    include: {
+      module: {
+        select: {
+          id: true,
+          title: true,
+        },
+      },
     },
   })
+
+  return parcoursModules.map((pm) => ({
+    id: pm.module.id,
+    title: pm.module.title,
+    order: pm.order,
+  }))
 }

--- a/lib/services/parcours.service.ts
+++ b/lib/services/parcours.service.ts
@@ -5,12 +5,15 @@ export async function getParcoursWithModules(parcoursId: string, userId: string)
   const parcours = await prisma.parcours.findUnique({
     where: { id: parcoursId },
     include: {
-      modules: {
+      parcoursModules: {
         orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          title: true,
-          order: true,
+        include: {
+          module: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
         },
       },
     },
@@ -24,16 +27,18 @@ export async function getParcoursWithModules(parcoursId: string, userId: string)
   const progress = await prisma.progress.findMany({
     where: {
       userId,
-      module: { parcoursId },
+      module: { parcoursModules: { some: { parcoursId } } },
     },
     select: { moduleId: true },
   })
 
   const completedModuleIds = new Set(progress.map((p) => p.moduleId))
 
-  const modulesWithStatus = parcours.modules.map((module) => ({
-    ...module,
-    isCompleted: completedModuleIds.has(module.id),
+  const modulesWithStatus = parcours.parcoursModules.map((pm) => ({
+    id: pm.module.id,
+    title: pm.module.title,
+    order: pm.order,
+    isCompleted: completedModuleIds.has(pm.module.id),
   }))
 
   return {
@@ -45,7 +50,7 @@ export async function getParcoursWithModules(parcoursId: string, userId: string)
     modules: modulesWithStatus,
     progress: {
       completed: completedModuleIds.size,
-      total: parcours.modules.length,
+      total: parcours.parcoursModules.length,
     },
   }
 }
@@ -88,13 +93,16 @@ export async function getUserParcours(userId: string, parcoursId?: string) {
   const parcours = await prisma.parcours.findUnique({
     where: { id: targetParcoursId },
     include: {
-      modules: {
+      parcoursModules: {
         orderBy: { order: 'asc' },
-        select: {
-          id: true,
-          title: true,
-          order: true,
-          quiz: { select: { id: true } },
+        include: {
+          module: {
+            select: {
+              id: true,
+              title: true,
+              quiz: { select: { id: true } },
+            },
+          },
         },
       },
     },
@@ -108,7 +116,7 @@ export async function getUserParcours(userId: string, parcoursId?: string) {
   const progress = await prisma.progress.findMany({
     where: {
       userId,
-      module: { parcoursId: targetParcoursId },
+      module: { parcoursModules: { some: { parcoursId: targetParcoursId } } },
     },
     select: {
       moduleId: true,
@@ -120,14 +128,14 @@ export async function getUserParcours(userId: string, parcoursId?: string) {
 
   const progressMap = new Map(progress.map((p) => [p.moduleId, p]))
 
-  const modulesWithStatus = parcours.modules.map((module) => {
-    const moduleProgress = progressMap.get(module.id)
+  const modulesWithStatus = parcours.parcoursModules.map((pm) => {
+    const moduleProgress = progressMap.get(pm.module.id)
     return {
-      id: module.id,
-      title: module.title,
-      order: module.order,
+      id: pm.module.id,
+      title: pm.module.title,
+      order: pm.order,
       isCompleted: !!moduleProgress,
-      hasQuiz: !!module.quiz,
+      hasQuiz: !!pm.module.quiz,
       quizScore: moduleProgress?.quizResult
         ? {
             score: moduleProgress.quizResult.score,
@@ -143,7 +151,7 @@ export async function getUserParcours(userId: string, parcoursId?: string) {
     user: { id: user.id, name: user.name, email: user.email },
     parcours: { id: parcours.id, title: parcours.title, description: parcours.description },
     modules: modulesWithStatus,
-    progress: { completed: progress.length, total: parcours.modules.length },
+    progress: { completed: progress.length, total: parcours.parcoursModules.length },
     nextModule,
   }
 }
@@ -154,7 +162,7 @@ export async function getUserParcoursAssignments(userId: string) {
     include: {
       parcours: {
         include: {
-          modules: { select: { id: true } },
+          parcoursModules: { select: { moduleId: true } },
         },
       },
     },
@@ -167,19 +175,19 @@ export async function getUserParcoursAssignments(userId: string) {
       where: { id: userId },
       include: {
         parcours: {
-          include: { modules: { select: { id: true } } },
+          include: { parcoursModules: { select: { moduleId: true } } },
         },
       },
     })
     if (user?.parcours) {
       const progress = await prisma.progress.findMany({
-        where: { userId, module: { parcoursId: user.parcours.id } },
+        where: { userId, module: { parcoursModules: { some: { parcoursId: user.parcours.id } } } },
         select: { moduleId: true },
       })
       return [{
         id: user.parcours.id,
         title: user.parcours.title,
-        totalModules: user.parcours.modules.length,
+        totalModules: user.parcours.parcoursModules.length,
         completedModules: progress.length,
       }]
     }
@@ -195,7 +203,7 @@ export async function getUserParcoursAssignments(userId: string) {
   return assignments.map((a) => ({
     id: a.parcours.id,
     title: a.parcours.title,
-    totalModules: a.parcours.modules.length,
-    completedModules: a.parcours.modules.filter((m) => completedModuleIds.has(m.id)).length,
+    totalModules: a.parcours.parcoursModules.length,
+    completedModules: a.parcours.parcoursModules.filter((pm) => completedModuleIds.has(pm.moduleId)).length,
   }))
 }

--- a/lib/services/progress.service.ts
+++ b/lib/services/progress.service.ts
@@ -29,35 +29,39 @@ export async function getUserProgress(userId: string, parcoursId?: string) {
     throw new ApiError(404, 'Aucun parcours assigné', 'NO_PARCOURS_ASSIGNED')
   }
 
-  const [progress, totalModules] = await Promise.all([
-    prisma.progress.findMany({
-      where: {
-        userId,
-        module: { parcoursId: targetParcoursId },
+  // Get the module IDs in this parcours via ParcoursModule
+  const parcoursModules = await prisma.parcoursModule.findMany({
+    where: { parcoursId: targetParcoursId },
+    orderBy: { order: 'asc' },
+    select: { moduleId: true, order: true },
+  })
+  const parcoursModuleIds = parcoursModules.map((pm) => pm.moduleId)
+  const orderByModuleId = new Map(parcoursModules.map((pm) => [pm.moduleId, pm.order]))
+
+  const progress = await prisma.progress.findMany({
+    where: {
+      userId,
+      moduleId: { in: parcoursModuleIds },
+    },
+    include: {
+      module: {
+        select: { id: true, title: true },
       },
-      include: {
-        module: {
-          select: { id: true, title: true, order: true },
-        },
-        quizResult: {
-          select: { score: true, totalQuestions: true },
-        },
+      quizResult: {
+        select: { score: true, totalQuestions: true },
       },
-      orderBy: { completedAt: 'desc' },
-    }),
-    prisma.module.count({
-      where: { parcoursId: targetParcoursId },
-    }),
-  ])
+    },
+    orderBy: { completedAt: 'desc' },
+  })
 
   return {
     completed: progress.length,
-    total: totalModules,
-    percentage: totalModules > 0 ? Math.round((progress.length / totalModules) * 100) : 0,
+    total: parcoursModuleIds.length,
+    percentage: parcoursModuleIds.length > 0 ? Math.round((progress.length / parcoursModuleIds.length) * 100) : 0,
     modules: progress.map((p) => ({
       moduleId: p.module.id,
       moduleTitle: p.module.title,
-      moduleOrder: p.module.order,
+      moduleOrder: orderByModuleId.get(p.module.id) ?? 0,
       completedAt: p.completedAt,
       quizScore: p.quizResult
         ? {
@@ -73,16 +77,31 @@ export async function markModuleAsCompleted(userId: string, moduleId: string, st
   // Verify module exists and user has access
   const module = await prisma.module.findUnique({
     where: { id: moduleId },
-    select: { id: true, parcoursId: true, minDuration: true },
+    select: {
+      id: true,
+      minDuration: true,
+      parcoursModules: {
+        select: { parcoursId: true, order: true },
+      },
+    },
   })
 
   if (!module) {
     throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
   }
 
+  // Use first parcoursModule as context
+  const pm = module.parcoursModules[0]
+  if (!pm) {
+    throw new ApiError(404, 'Module non associé à un parcours', 'MODULE_NOT_FOUND')
+  }
+
+  const parcoursId = pm.parcoursId
+  const moduleOrder = pm.order
+
   // Check access via UserParcours
   const hasAccess = await prisma.userParcours.findUnique({
-    where: { userId_parcoursId: { userId, parcoursId: module.parcoursId } },
+    where: { userId_parcoursId: { userId, parcoursId } },
   })
 
   if (!hasAccess) {
@@ -91,7 +110,7 @@ export async function markModuleAsCompleted(userId: string, moduleId: string, st
       where: { id: userId },
       select: { parcoursId: true },
     })
-    if (user?.parcoursId !== module.parcoursId) {
+    if (user?.parcoursId !== parcoursId) {
       throw new ApiError(403, 'Accès non autorisé à ce module', 'MODULE_ACCESS_DENIED')
     }
   }
@@ -124,19 +143,19 @@ export async function markModuleAsCompleted(userId: string, moduleId: string, st
     },
     include: {
       module: {
-        select: { title: true, order: true },
+        select: { title: true },
       },
     },
   })
 
-  // Find next module
-  const nextModule = await prisma.module.findFirst({
+  // Find next module via ParcoursModule
+  const nextPM = await prisma.parcoursModule.findFirst({
     where: {
-      parcoursId: module.parcoursId,
-      order: { gt: progress.module.order },
+      parcoursId,
+      order: { gt: moduleOrder },
     },
     orderBy: { order: 'asc' },
-    select: { id: true, title: true },
+    include: { module: { select: { id: true, title: true } } },
   })
 
   // Check and award badges (fire-and-forget)
@@ -145,6 +164,6 @@ export async function markModuleAsCompleted(userId: string, moduleId: string, st
   return {
     alreadyCompleted: false,
     progress,
-    nextModule,
+    nextModule: nextPM ? { id: nextPM.module.id, title: nextPM.module.title } : null,
   }
 }

--- a/lib/services/quiz.service.ts
+++ b/lib/services/quiz.service.ts
@@ -35,23 +35,29 @@ export interface QuizResultData {
   }[]
 }
 
+/** Resolve a parcoursId for a given module via ParcoursModule */
+async function resolveModuleParcoursId(moduleId: string): Promise<string | null> {
+  const pm = await prisma.parcoursModule.findFirst({
+    where: { moduleId },
+    select: { parcoursId: true },
+  })
+  return pm?.parcoursId ?? null
+}
+
 export async function getModuleQuiz(
   moduleId: string,
   userId: string
 ): Promise<QuizWithQuestions | null> {
   // Verify user has access to this module
-  const module = await prisma.module.findUnique({
-    where: { id: moduleId },
-    select: { parcoursId: true },
-  })
+  const parcoursId = await resolveModuleParcoursId(moduleId)
 
-  if (!module) {
+  if (!parcoursId) {
     throw new ApiError(404, 'Module non trouvé', 'MODULE_NOT_FOUND')
   }
 
   // Check access via UserParcours first
   const hasAccess = await prisma.userParcours.findUnique({
-    where: { userId_parcoursId: { userId, parcoursId: module.parcoursId } },
+    where: { userId_parcoursId: { userId, parcoursId } },
   })
 
   if (!hasAccess) {
@@ -60,7 +66,7 @@ export async function getModuleQuiz(
       where: { id: userId },
       select: { parcoursId: true },
     })
-    if (user?.parcoursId !== module.parcoursId) {
+    if (user?.parcoursId !== parcoursId) {
       throw new ApiError(403, 'Accès non autorisé à ce module', 'MODULE_ACCESS_DENIED')
     }
   }
@@ -113,7 +119,7 @@ export async function submitQuiz(
     where: { id: quizId },
     include: {
       module: {
-        select: { id: true, parcoursId: true },
+        select: { id: true },
       },
       questions: {
         include: {
@@ -127,18 +133,23 @@ export async function submitQuiz(
     throw new ApiError(404, 'Quiz non trouvé', 'QUIZ_NOT_FOUND')
   }
 
-  // Verify user has access via UserParcours first
-  const hasAccess = await prisma.userParcours.findUnique({
-    where: { userId_parcoursId: { userId, parcoursId: quiz.module.parcoursId } },
-  })
+  // Resolve parcoursId via ParcoursModule
+  const parcoursId = await resolveModuleParcoursId(quiz.module.id)
 
-  if (!hasAccess) {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { parcoursId: true },
+  if (parcoursId) {
+    // Verify user has access via UserParcours first
+    const hasAccess = await prisma.userParcours.findUnique({
+      where: { userId_parcoursId: { userId, parcoursId } },
     })
-    if (user?.parcoursId !== quiz.module.parcoursId) {
-      throw new ApiError(403, 'Accès non autorisé à ce quiz', 'QUIZ_ACCESS_DENIED')
+
+    if (!hasAccess) {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { parcoursId: true },
+      })
+      if (user?.parcoursId !== parcoursId) {
+        throw new ApiError(403, 'Accès non autorisé à ce quiz', 'QUIZ_ACCESS_DENIED')
+      }
     }
   }
 

--- a/lib/services/trainer.service.ts
+++ b/lib/services/trainer.service.ts
@@ -70,7 +70,7 @@ export async function getTrainerStats(
         userParcours: {
           include: {
             parcours: {
-              include: { modules: { select: { id: true } } },
+              include: { parcoursModules: { select: { moduleId: true } } },
             },
           },
         },
@@ -87,7 +87,7 @@ export async function getTrainerStats(
 
   for (const learner of learners) {
     const allModuleIds = learner.userParcours.flatMap((up) =>
-      up.parcours.modules.map((m) => m.id)
+      up.parcours.parcoursModules.map((pm) => pm.moduleId)
     )
     const totalModules = allModuleIds.length
     if (totalModules === 0) continue
@@ -159,7 +159,7 @@ export async function getTrainerLearners(
       userParcours: {
         include: {
           parcours: {
-            include: { modules: { select: { id: true } } },
+            include: { parcoursModules: { select: { moduleId: true } } },
           },
         },
       },
@@ -172,7 +172,7 @@ export async function getTrainerLearners(
 
   for (const learner of learners) {
     const allModuleIds = learner.userParcours.flatMap((up) =>
-      up.parcours.modules.map((m) => m.id)
+      up.parcours.parcoursModules.map((pm) => pm.moduleId)
     )
     const totalModules = allModuleIds.length
     const completedModuleIds = new Set(learner.progress.map((p) => p.moduleId))
@@ -234,20 +234,23 @@ export async function getLearnerDetails(
         include: {
           parcours: {
             include: {
-              modules: {
+              parcoursModules: {
                 orderBy: { order: 'asc' },
-                select: {
-                  id: true,
-                  title: true,
-                  order: true,
-                  quiz: {
-                    include: {
-                      questions: {
-                        orderBy: { order: 'asc' },
+                include: {
+                  module: {
+                    select: {
+                      id: true,
+                      title: true,
+                      quiz: {
                         include: {
-                          answers: {
+                          questions: {
                             orderBy: { order: 'asc' },
-                            select: { id: true, text: true, isCorrect: true },
+                            include: {
+                              answers: {
+                                orderBy: { order: 'asc' },
+                                select: { id: true, text: true, isCorrect: true },
+                              },
+                            },
                           },
                         },
                       },
@@ -263,7 +266,7 @@ export async function getLearnerDetails(
       progress: {
         include: {
           module: {
-            select: { id: true, title: true, order: true },
+            select: { id: true, title: true },
           },
           quizResult: {
             select: { score: true, totalQuestions: true, answers: true },
@@ -287,7 +290,8 @@ export async function getLearnerDetails(
   const primaryParcours = primaryUp?.parcours || null
 
   const modulesWithProgress =
-    primaryParcours?.modules.map((module) => {
+    primaryParcours?.parcoursModules.map((pm) => {
+      const module = pm.module
       const progress = learner.progress.find(
         (p) => p.moduleId === module.id
       )
@@ -312,7 +316,7 @@ export async function getLearnerDetails(
       return {
         id: module.id,
         title: module.title,
-        order: module.order,
+        order: pm.order,
         isCompleted: completedModuleIds.has(module.id),
         completedAt: progress?.completedAt || null,
         hasQuiz: !!module.quiz,
@@ -343,11 +347,11 @@ export async function getLearnerDetails(
     modules: modulesWithProgress,
     progress: {
       completed: learner.progress.length,
-      total: primaryParcours?.modules.length || 0,
+      total: primaryParcours?.parcoursModules.length || 0,
       percentage:
-        primaryParcours?.modules.length
+        primaryParcours?.parcoursModules.length
           ? Math.round(
-              (learner.progress.length / primaryParcours.modules.length) * 100
+              (learner.progress.length / primaryParcours.parcoursModules.length) * 100
             )
           : 0,
     },

--- a/lib/services/user-management.service.ts
+++ b/lib/services/user-management.service.ts
@@ -221,12 +221,12 @@ export async function unassignParcours(data: { userId: string; parcoursId: strin
     where: { userId: data.userId, parcoursId: data.parcoursId },
   })
 
-  // Delete progress for modules in this parcours
-  const modules = await prisma.module.findMany({
+  // Delete progress for modules in this parcours (via ParcoursModule)
+  const parcoursModules = await prisma.parcoursModule.findMany({
     where: { parcoursId: data.parcoursId },
-    select: { id: true },
+    select: { moduleId: true },
   })
-  const moduleIds = modules.map((m) => m.id)
+  const moduleIds = parcoursModules.map((pm) => pm.moduleId)
 
   if (moduleIds.length > 0) {
     await prisma.progress.deleteMany({
@@ -329,7 +329,15 @@ export async function getUsers(options?: {
     include: {
       trainer: { select: { id: true, name: true } },
       userParcours: {
-        include: { parcours: { select: { id: true, title: true, modules: { select: { id: true } } } } },
+        include: {
+          parcours: {
+            select: {
+              id: true,
+              title: true,
+              parcoursModules: { select: { moduleId: true } },
+            },
+          },
+        },
         orderBy: { assignedAt: 'desc' },
       },
       progress: { select: { moduleId: true } },
@@ -338,7 +346,7 @@ export async function getUsers(options?: {
   })
 
   return users.map((user) => {
-    const allModuleIds = user.userParcours.flatMap((up) => up.parcours.modules.map((m) => m.id))
+    const allModuleIds = user.userParcours.flatMap((up) => up.parcours.parcoursModules.map((pm) => pm.moduleId))
     const completedModuleIds = user.progress.map((p) => p.moduleId)
     const completedCount = allModuleIds.filter((id) => completedModuleIds.includes(id)).length
 
@@ -350,8 +358,9 @@ export async function getUsers(options?: {
       createdAt: user.createdAt,
       trainer: user.trainer,
       parcours: user.userParcours.map((up) => {
-        const totalModules = up.parcours.modules.length
-        const completed = up.parcours.modules.filter((m) => completedModuleIds.includes(m.id)).length
+        const moduleIds = up.parcours.parcoursModules.map((pm) => pm.moduleId)
+        const totalModules = moduleIds.length
+        const completed = moduleIds.filter((id) => completedModuleIds.includes(id)).length
         return {
           id: up.parcours.id,
           title: up.parcours.title,

--- a/lib/services/xp.service.ts
+++ b/lib/services/xp.service.ts
@@ -59,13 +59,15 @@ export async function getBulkUserXP(userIds: string[]): Promise<Map<string, XPBr
   })
   const badgeCountByUser = new Map(badgeCounts.map((b) => [b.userId, b._count]))
 
-  // 4. Parcours complétés — charger les assignments + modules en une seule requête
+  // 4. Parcours complétés — charger les assignments + modules via ParcoursModule
   const userParcoursData = await prisma.userParcours.findMany({
     where: { userId: { in: userIds } },
     select: {
       userId: true,
       parcours: {
-        select: { modules: { select: { id: true } } },
+        select: {
+          parcoursModules: { select: { moduleId: true } },
+        },
       },
     },
   })
@@ -107,9 +109,10 @@ export async function getBulkUserXP(userIds: string[]): Promise<Map<string, XPBr
     let parcoursXP = 0
     const userAssignments = userParcoursData.filter((up) => up.userId === userId)
     for (const up of userAssignments) {
-      const totalModules = up.parcours.modules.length
+      const moduleIds = up.parcours.parcoursModules.map((pm) => pm.moduleId)
+      const totalModules = moduleIds.length
       if (totalModules > 0) {
-        const done = up.parcours.modules.filter((m) => completedSet.has(m.id)).length
+        const done = moduleIds.filter((id) => completedSet.has(id)).length
         if (done >= totalModules) parcoursXP += XP_PARCOURS_COMPLETE
       }
     }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,11 +58,11 @@ model Parcours {
   title       String
   description String @default("")
 
-  modules      Module[]
-  users        User[]        @relation("LegacyUserParcours")
-  userParcours UserParcours[]
-  invitations  Invitation[]
-  feedbacks    Feedback[]
+  parcoursModules ParcoursModule[]
+  users           User[]        @relation("LegacyUserParcours")
+  userParcours    UserParcours[]
+  invitations     Invitation[]
+  feedbacks       Feedback[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -70,24 +70,34 @@ model Parcours {
   @@map("parcours")
 }
 
+model ParcoursModule {
+  id         String   @id @default(uuid())
+  parcoursId String   @map("parcours_id")
+  parcours   Parcours @relation(fields: [parcoursId], references: [id], onDelete: Cascade)
+  moduleId   String   @map("module_id")
+  module     Module   @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  order      Int      @default(0)
+
+  @@unique([parcoursId, moduleId])
+  @@index([parcoursId, order])
+  @@index([moduleId])
+  @@map("parcours_modules")
+}
+
 model Module {
-  id      String @id @default(uuid())
-  title   String
-  content String @db.Text
-  order       Int    @default(0)
+  id          String @id @default(uuid())
+  title       String
+  content     String @db.Text
   minDuration Int    @default(0) @map("min_duration")
   published   Boolean @default(false)
 
-  parcoursId String   @map("parcours_id")
-  parcours   Parcours @relation(fields: [parcoursId], references: [id], onDelete: Cascade)
-
-  quiz     Quiz?
-  progress Progress[]
+  parcoursModules ParcoursModule[]
+  quiz            Quiz?
+  progress        Progress[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@index([parcoursId, order])
   @@map("modules")
 }
 


### PR DESCRIPTION
closes #9

- Nouveau modèle ParcoursModule (table pivot) remplaçant Module.parcoursId
- Script de migration SQL pour les données existantes
- 50+ fichiers adaptés (services, API, composants)
- Formulaire module : checkboxes multi-parcours au lieu du select unique
- Bouton "Module existant" dans le détail parcours pour réutiliser un module
- Dialog recherche avec badges parcours actuels
- Cards modules : affichage multi-parcours (max 2 + badge overflow)
- Preview module : badges de tous les parcours associés
- Progression liée au module (complété une fois = complété partout)

## Description

Refactoring majeur de la relation Module ↔ Parcours : passage d'un lien one-to-many (`Module.parcoursId`) à un many-to-many via une table pivot `ParcoursModule`. Un module peut désormais être réutilisé dans plusieurs parcours sans duplication. La progression d'un apprenant est liée au module — un module complété dans un parcours est automatiquement marqué comme complété dans tous les autres parcours où il apparaît.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [x] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🔒 Sécurité
- [ ] ⚡ Performance

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [ ] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [x] La documentation a été mise à jour si nécessaire
- [x] Les migrations Prisma sont incluses si nécessaire

## Captures d'écran (si applicable)

N/A
