### PR TITLE
Dev

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,7 +51,7 @@
   --radius: 0.625rem;
   --background: oklch(0.98 0.006 250);
   --foreground: oklch(0.20 0.03 250);
-  --card: oklch(0.98 0.012 55);
+  --card: oklch(1 0 0);
   --card-foreground: oklch(0.20 0.03 250);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.20 0.03 250);
@@ -72,13 +72,13 @@
   --chart-3: oklch(0.60 0.12 160);
   --chart-4: oklch(0.72 0.08 230);
   --chart-5: oklch(0.55 0.15 320);
-  --sidebar: oklch(0.97 0.012 55);
-  --sidebar-foreground: oklch(0.25 0.03 40);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.20 0.03 250);
   --sidebar-primary: oklch(0.38 0.08 250);
   --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.94 0.02 55);
-  --sidebar-accent-foreground: oklch(0.25 0.03 40);
-  --sidebar-border: oklch(0.91 0.015 55);
+  --sidebar-accent: oklch(0.95 0.005 250);
+  --sidebar-accent-foreground: oklch(0.20 0.03 250);
+  --sidebar-border: oklch(0.92 0.005 250);
   --sidebar-ring: oklch(0.55 0.08 250);
 }
 

--- a/lib/auth/magic-link-email.ts
+++ b/lib/auth/magic-link-email.ts
@@ -8,6 +8,11 @@ interface SendVerificationRequestParams {
 }
 
 const FROM_EMAIL = process.env.EMAIL_FROM || 'FormaCPV <onboarding@resend.dev>'
+const APP_URL = process.env.NEXTAUTH_URL || 'http://localhost:3000'
+const LOGO_URL = `${APP_URL}/logo-pointvision.png`
+const PV_BLUE = '#2B4C7E'
+const PV_BLUE_LIGHT = '#7EADD4'
+const PV_BLUE_DARK = '#1E3A5F'
 
 export async function sendMagicLinkEmail(
   params: SendVerificationRequestParams
@@ -36,18 +41,19 @@ export async function sendMagicLinkEmail(
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Connexion FormaCPV</title>
           </head>
-          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-            <div style="text-align: center; margin-bottom: 30px;">
-              <h1 style="color: #2563EB; margin: 0;">FormaCPV</h1>
-              <p style="color: #6B7280; margin: 5px 0 0;">Formation Professionnelle</p>
+          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #F8FAFC;">
+            <div style="background: linear-gradient(135deg, ${PV_BLUE}, ${PV_BLUE_DARK}); border-radius: 12px 12px 0 0; padding: 28px 24px; text-align: center;">
+              <img src="${LOGO_URL}" alt="Point Vision" width="52" height="52" style="border-radius: 10px; margin-bottom: 10px;" />
+              <h1 style="color: white; margin: 0; font-size: 24px; letter-spacing: 0.5px;">FormaCPV</h1>
+              <p style="color: ${PV_BLUE_LIGHT}; margin: 6px 0 0; font-size: 13px; letter-spacing: 0.3px;">Plateforme de formation &mdash; Groupe Point Vision</p>
             </div>
 
-            <div style="background: #F9FAFB; border-radius: 8px; padding: 30px; margin-bottom: 20px;">
-              <h2 style="margin-top: 0; color: #1F2937;">Connexion à votre compte</h2>
+            <div style="background: white; border-radius: 0 0 12px 12px; padding: 30px; margin-bottom: 20px; border: 1px solid #E2E8F0; border-top: none;">
+              <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Connexion à votre compte</h2>
               <p>Cliquez sur le bouton ci-dessous pour vous connecter :</p>
 
               <div style="text-align: center; margin: 30px 0;">
-                <a href="${url}" style="display: inline-block; background: #2563EB; color: white; padding: 14px 30px; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
+                <a href="${url}" style="display: inline-block; background: ${PV_BLUE}; color: white; padding: 14px 30px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
                   Se connecter
                 </a>
               </div>
@@ -58,6 +64,7 @@ export async function sendMagicLinkEmail(
             </div>
 
             <div style="text-align: center; color: #9CA3AF; font-size: 12px;">
+              <p>L'ophtalmologie de pointe &mdash; Groupe Point Vision</p>
               <p>&copy; ${new Date().getFullYear()} FormaCPV. Tous droits réservés.</p>
             </div>
           </body>

--- a/lib/services/email-templates.ts
+++ b/lib/services/email-templates.ts
@@ -1,4 +1,8 @@
 const APP_URL = process.env.NEXTAUTH_URL || 'http://localhost:3000'
+const LOGO_URL = `${APP_URL}/logo-pointvision.png`
+const PV_BLUE = '#2B4C7E'
+const PV_BLUE_LIGHT = '#7EADD4'
+const PV_BLUE_DARK = '#1E3A5F'
 
 function unsubscribeFooter(): string {
   const prefsLink = `${APP_URL}/profile#notifications`
@@ -12,16 +16,18 @@ function layout(content: string, footer?: string): string {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
-  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="text-align: center; margin-bottom: 30px;">
-      <h1 style="color: #2563EB; margin: 0;">FormaCPV</h1>
-      <p style="color: #6B7280; margin: 5px 0 0;">Formation Professionnelle</p>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #F8FAFC;">
+    <div style="background: linear-gradient(135deg, ${PV_BLUE}, ${PV_BLUE_DARK}); border-radius: 12px 12px 0 0; padding: 28px 24px; text-align: center;">
+      <img src="${LOGO_URL}" alt="Point Vision" width="52" height="52" style="border-radius: 10px; margin-bottom: 10px;" />
+      <h1 style="color: white; margin: 0; font-size: 24px; letter-spacing: 0.5px;">FormaCPV</h1>
+      <p style="color: ${PV_BLUE_LIGHT}; margin: 6px 0 0; font-size: 13px; letter-spacing: 0.3px;">Plateforme de formation &mdash; Groupe Point Vision</p>
     </div>
-    <div style="background: #F9FAFB; border-radius: 8px; padding: 30px; margin-bottom: 20px;">
+    <div style="background: white; border-radius: 0 0 12px 12px; padding: 30px; margin-bottom: 20px; border: 1px solid #E2E8F0; border-top: none;">
       ${content}
     </div>
-    <div style="text-align: center; color: #9CA3AF; font-size: 12px;">
+    <div style="text-align: center; color: #9CA3AF; font-size: 12px; padding: 0 20px;">
       ${footer || ''}
+      <p style="margin-top: 12px;">L'ophtalmologie de pointe &mdash; Groupe Point Vision</p>
       <p>&copy; ${new Date().getFullYear()} FormaCPV. Tous droits réservés.</p>
     </div>
   </body>
@@ -30,15 +36,15 @@ function layout(content: string, footer?: string): string {
 
 function ctaButton(href: string, label: string): string {
   return `<div style="text-align: center; margin: 30px 0;">
-  <a href="${href}" style="display: inline-block; background: #2563EB; color: white; padding: 14px 30px; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
+  <a href="${href}" style="display: inline-block; background: ${PV_BLUE}; color: white; padding: 14px 30px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
     ${label}
   </a>
 </div>`
 }
 
-function listBlock(items: string[], borderColor = '#2563EB'): string {
+function listBlock(items: string[], borderColor = PV_BLUE): string {
   const lis = items.map((t) => `<li style="margin: 5px 0;"><strong>${t}</strong></li>`).join('')
-  return `<ul style="background: white; border-radius: 6px; padding: 15px 15px 15px 30px; margin: 20px 0; border-left: 4px solid ${borderColor};">
+  return `<ul style="background: #F8FAFC; border-radius: 8px; padding: 15px 15px 15px 30px; margin: 20px 0; border-left: 4px solid ${borderColor};">
   ${lis}
 </ul>`
 }
@@ -52,12 +58,12 @@ export function invitationTemplate(p: {
   expirationDate: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Vous êtes invité(e) à rejoindre une formation</h2>
-    <p>${p.trainerName} vous invite à suivre le parcours de formation:</p>
-    <div style="background: white; border-radius: 6px; padding: 15px; margin: 20px 0; border-left: 4px solid #2563EB;">
-      <strong style="font-size: 18px; color: #2563EB;">${p.parcoursTitle}</strong>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Vous êtes invité(e) à rejoindre une formation</h2>
+    <p>${p.trainerName} vous invite à suivre le parcours de formation :</p>
+    <div style="background: #F8FAFC; border-radius: 8px; padding: 15px; margin: 20px 0; border-left: 4px solid ${PV_BLUE};">
+      <strong style="font-size: 18px; color: ${PV_BLUE};">${p.parcoursTitle}</strong>
     </div>
-    <p>Cliquez sur le bouton ci-dessous pour créer votre compte et commencer votre formation:</p>
+    <p>Cliquez sur le bouton ci-dessous pour créer votre compte et commencer votre formation :</p>
     ${ctaButton(p.inviteLink, 'Commencer ma formation')}
     <p style="color: #6B7280; font-size: 14px;">
       Ce lien expire le <strong>${p.expirationDate}</strong>.
@@ -75,7 +81,7 @@ export function welcomeTemplate(p: {
   loginLink: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Bienvenue sur FormaCPV !</h2>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Bienvenue sur FormaCPV !</h2>
     <p>${p.trainerName} vous a inscrit aux formations suivantes :</p>
     ${listBlock(p.parcoursTitles)}
     <p>Connectez-vous pour commencer vos formations :</p>
@@ -91,10 +97,10 @@ export function trainerWelcomeTemplate(p: {
   loginLink: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Bienvenue en tant que formateur !</h2>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Bienvenue en tant que formateur !</h2>
     <p>Vous avez été ajouté comme <strong>formateur</strong> sur la plateforme FormaCPV.</p>
     <p>Vous pouvez dès maintenant :</p>
-    <ul style="background: white; border-radius: 6px; padding: 15px 15px 15px 30px; margin: 20px 0; border-left: 4px solid #2563EB;">
+    <ul style="background: #F8FAFC; border-radius: 8px; padding: 15px 15px 15px 30px; margin: 20px 0; border-left: 4px solid ${PV_BLUE};">
       <li style="margin: 5px 0;">Consulter vos parcours de formation</li>
       <li style="margin: 5px 0;">Inviter et suivre vos apprenants</li>
       <li style="margin: 5px 0;">Suivre leur progression en temps réel</li>
@@ -113,7 +119,7 @@ export function parcoursAssignmentTemplate(p: {
   loginLink: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Nouvelle formation disponible</h2>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Nouvelle formation disponible</h2>
     <p>${p.trainerName} vous a assigné de nouvelles formations :</p>
     ${listBlock(p.parcoursTitles, '#10B981')}
     <p>Connectez-vous pour commencer :</p>
@@ -130,7 +136,7 @@ export function contentUpdateTemplate(p: {
   loginLink: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Contenu mis à jour</h2>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Contenu mis à jour</h2>
     <p>${p.description}</p>
     <p style="color: #6B7280;">De nouvelles informations sont disponibles. Connectez-vous pour consulter les changements.</p>
     ${ctaButton(p.loginLink, 'Voir les mises à jour')}
@@ -149,10 +155,10 @@ export function contactTemplate(p: {
   escapedMessage: string
 }): { html: string; text: string } {
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">${p.subject}</h2>
-    <div style="background: white; border-radius: 6px; padding: 15px; margin: 20px 0; border-left: 4px solid #2563EB;">
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">${p.subject}</h2>
+    <div style="background: #F8FAFC; border-radius: 8px; padding: 15px; margin: 20px 0; border-left: 4px solid ${PV_BLUE};">
       <p style="margin: 0 0 10px 0; font-size: 14px; color: #6B7280;">
-        <strong>${p.fromName}</strong> (${p.roleLabel}) — <a href="mailto:${p.fromEmail}" style="color: #2563EB;">${p.fromEmail}</a>
+        <strong>${p.fromName}</strong> (${p.roleLabel}) — <a href="mailto:${p.fromEmail}" style="color: ${PV_BLUE};">${p.fromEmail}</a>
       </p>
       <p style="margin: 0; white-space: pre-wrap;">${p.escapedMessage}</p>
     </div>
@@ -177,24 +183,20 @@ export function reminderTemplate(p: {
   const loginUrl = `${APP_URL}/learner`
 
   const html = layout(`
-    <h2 style="margin-top: 0; color: #1F2937;">Vos formations vous attendent !</h2>
+    <h2 style="margin-top: 0; color: ${PV_BLUE_DARK};">Vos formations vous attendent !</h2>
     <p>Bonjour <strong>${p.learnerName}</strong>,</p>
     <p>Cela fait <strong>${p.daysSinceLastActivity} jour${p.daysSinceLastActivity > 1 ? 's' : ''}</strong> que vous ne vous êtes pas connecté à FormaCPV.</p>
-    <div style="background: white; border-radius: 6px; padding: 15px; margin: 20px 0;">
-      <p style="margin: 0 0 5px 0; font-weight: bold;">${p.parcoursTitle}</p>
+    <div style="background: #F8FAFC; border-radius: 8px; padding: 15px; margin: 20px 0;">
+      <p style="margin: 0 0 5px 0; font-weight: bold; color: ${PV_BLUE_DARK};">${p.parcoursTitle}</p>
       <p style="margin: 0; color: #6B7280;">
         ${p.completedModules}/${p.totalModules} modules complétés (${progressPercent}%)
       </p>
-      <div style="background: #E5E7EB; border-radius: 999px; height: 8px; margin-top: 10px;">
-        <div style="background: #2563EB; border-radius: 999px; height: 8px; width: ${progressPercent}%;"></div>
+      <div style="background: #E2E8F0; border-radius: 999px; height: 8px; margin-top: 10px;">
+        <div style="background: ${PV_BLUE}; border-radius: 999px; height: 8px; width: ${progressPercent}%;"></div>
       </div>
     </div>
     <p>Continuez votre progression et terminez votre parcours !</p>
-    <div style="text-align: center; margin: 25px 0;">
-      <a href="${loginUrl}" style="display: inline-block; padding: 12px 30px; background: #2563EB; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">
-        Reprendre ma formation
-      </a>
-    </div>
+    ${ctaButton(loginUrl, 'Reprendre ma formation')}
   `, unsubscribeFooter())
 
   const text = `Bonjour ${p.learnerName},\n\nCela fait ${p.daysSinceLastActivity} jours que vous ne vous êtes pas connecté à FormaCPV.\n\n${p.parcoursTitle} : ${p.completedModules}/${p.totalModules} modules (${progressPercent}%)\n\nReprenez votre formation : ${loginUrl}`


### PR DESCRIPTION
closes #18

- Emails brandés : header dégradé bleu PV avec logo, boutons bleu PV, footer Groupe Point Vision
- Magic link : même style que les templates transactionnels
- 7 templates email + magic link mis à jour
- Cards : retour au blanc pur en light mode (moins fatiguant)
- Sidebar : quasi-blanche avec micro accent bleu PV
- Suppression de la teinte pêche sur les fonds (retour utilisateur)

## Description

Refonte des templates email avec la charte Point Vision (header dégradé bleu, logo, boutons brandés) et ajustement des fonds en light mode pour réduire la fatigue visuelle. Les cards et la sidebar reviennent à un fond neutre, seul le background body conserve un léger dégradé bleuté.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [x] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🔒 Sécurité
- [ ] ⚡ Performance

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [ ] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [x] La documentation a été mise à jour si nécessaire
- [ ] Les migrations Prisma sont incluses si nécessaire

## Captures d'écran (si applicable)

N/A — templates email testables via envoi réel
