### PR TITLE
fix: drag & drop des questions association — zone de drag étendue

### DIFF
--- a/components/learner/QuizQuestion.tsx
+++ b/components/learner/QuizQuestion.tsx
@@ -11,6 +11,8 @@ import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  TouchSensor,
+  KeyboardSensor,
   useSensor,
   useSensors,
   useDraggable,
@@ -119,7 +121,9 @@ export function QuizQuestion({
   })[0]
 
   const matchSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor)
   )
 
   const handleMatchDragStart = (event: DragStartEvent) => {
@@ -392,17 +396,16 @@ function DraggableMatch({
       ref={setNodeRef}
       style={style}
       className={cn(
-        'rounded-lg border p-3 transition-all flex items-center gap-2',
+        'rounded-lg border p-3 transition-all flex items-center gap-2 touch-none select-none',
         !disabled && 'cursor-grab active:cursor-grabbing',
         isDragging && 'opacity-50 shadow-lg z-50',
         className
       )}
       {...attributes}
+      {...(disabled ? {} : listeners)}
     >
       {!disabled && (
-        <button type="button" className="touch-none shrink-0 text-muted-foreground" {...listeners}>
-          <GripVertical className="h-4 w-4" />
-        </button>
+        <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground" />
       )}
       <div className="flex-1 min-w-0">{children}</div>
     </div>


### PR DESCRIPTION
closes #24

- Toute la card draggable devient zone de drag (plus seulement l'icône grip)
- Ajout TouchSensor pour le mobile (délai 200ms)
- Ajout KeyboardSensor pour l'accessibilité
- touch-none + select-none pour éviter les conflits scroll/sélection

## Description

Correction du drag & drop sur les questions de type association : la zone de drag était limitée à la petite icône grip (16px), rendant l'interaction difficile. Toute la card est maintenant draggable, avec support du tactile et du clavier.

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🔒 Sécurité
- [ ] ⚡ Performance

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [ ] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [ ] La documentation a été mise à jour si nécessaire
- [ ] Les migrations Prisma sont incluses si nécessaire

## Captures d'écran (si applicable)

N/A
