### PR TITLE
fix: quiz association tolère les matchText en doublon

### DIFF
--- a/components/learner/QuizQuestion.tsx
+++ b/components/learner/QuizQuestion.tsx
@@ -165,12 +165,19 @@ export function QuizQuestion({
     onAnswerChange(questionId, pairs)
   }
 
+  // Une paire est correcte si le matchText du rightId == matchText du leftId
+  const isMatchPairCorrect = (leftId: string, rightId: string) => {
+    const left = answers.find((a) => a.id === leftId)
+    const right = answers.find((a) => a.id === rightId)
+    if (!left || !right) return false
+    return (left.matchText ?? '') === (right.matchText ?? '')
+  }
+
   const getMatchClass = (leftId: string) => {
     if (!showResult || !correctAnswers) return ''
     const selectedRight = matchSelections[leftId]
     if (!selectedRight) return ''
-    const correctPair = correctAnswers.find((c) => c.startsWith(`${leftId}:`))
-    if (correctPair === `${leftId}:${selectedRight}`) return 'border-green-500 bg-green-50 dark:bg-green-950'
+    if (isMatchPairCorrect(leftId, selectedRight)) return 'border-green-500 bg-green-50 dark:bg-green-950'
     return 'border-red-500 bg-red-50 dark:bg-red-950'
   }
 
@@ -178,8 +185,7 @@ export function QuizQuestion({
     if (!showResult || !correctAnswers) return ''
     const leftId = Object.entries(matchSelections).find(([, v]) => v === rightId)?.[0]
     if (!leftId) return ''
-    const correctPair = correctAnswers.find((c) => c.startsWith(`${leftId}:`))
-    if (correctPair === `${leftId}:${rightId}`) return 'border-green-500 bg-green-50 dark:bg-green-950'
+    if (isMatchPairCorrect(leftId, rightId)) return 'border-green-500 bg-green-50 dark:bg-green-950'
     return 'border-red-500 bg-red-50 dark:bg-red-950'
   }
 

--- a/lib/services/quiz.service.ts
+++ b/lib/services/quiz.service.ts
@@ -190,11 +190,22 @@ export async function submitQuiz(
         correctAnswers: correctOrder,
       })
     } else if (question.type === 'MATCHING') {
-      // Pour l'association : format "leftId:rightId", correct = leftId:leftId (même answer)
+      // Format "leftId:rightId". Une paire est correcte si le matchText du rightId
+      // correspond au matchText attendu par le leftId (tolère les doublons de matchText).
+      const answersById = new Map(question.answers.map((a) => [a.id, a]))
       const correctPairs = question.answers.map((a) => `${a.id}:${a.id}`)
+
+      const isPairCorrect = (pair: string) => {
+        const [leftId, rightId] = pair.split(':')
+        const left = answersById.get(leftId)
+        const right = answersById.get(rightId)
+        if (!left || !right) return false
+        return (left.matchText ?? '') === (right.matchText ?? '')
+      }
+
       const isCorrect =
-        selectedAnswerIds.length === correctPairs.length &&
-        correctPairs.every((pair) => selectedAnswerIds.includes(pair))
+        selectedAnswerIds.length === question.answers.length &&
+        selectedAnswerIds.every(isPairCorrect)
       if (isCorrect) correctCount++
       results.push({
         questionId: question.id,


### PR DESCRIPTION
closes #27

- Comparaison sur matchText au lieu de l'id strict côté serveur
- Logique identique côté client pour la mise en couleur de la review
- Plusieurs paires peuvent partager le même matchText sans être pénalisées"