### PR TITLE
fix: blocage navigation pendant le timer du module

### DIFF
--- a/components/learner/ModulePageClient.tsx
+++ b/components/learner/ModulePageClient.tsx
@@ -10,6 +10,7 @@ import { FeedbackModal } from './FeedbackModal'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { PageBreadcrumb } from '@/components/shared/PageBreadcrumb'
+import { NavigationBlocker } from '@/components/shared/NavigationBlocker'
 import { Loader2, PartyPopper } from 'lucide-react'
 
 interface ModuleData {
@@ -246,8 +247,22 @@ export function ModulePageClient({ data, initialQuizReview }: ModulePageClientPr
   }
 
   // Module view
+  const minutes = Math.floor(timeRemaining / 60)
+  const seconds = timeRemaining % 60
+  const remainingLabel = minutes > 0
+    ? `${minutes} min ${String(seconds).padStart(2, '0')} s`
+    : `${seconds} s`
+  const navigationBlocked =
+    !moduleCompleted && minDurationSeconds > 0 && !isTimeElapsed
+
   return (
     <div className="space-y-6">
+      <NavigationBlocker
+        active={navigationBlocked}
+        title="Quitter le module ?"
+        message={`Il vous reste ${remainingLabel} avant de pouvoir valider ce module. Si vous quittez maintenant, votre progression ne sera pas enregistrée et vous devrez recommencer.`}
+      />
+
       <PageBreadcrumb items={[
         { label: 'Mes formations', href: '/learner' },
         { label: data.module.title },

--- a/components/shared/NavigationBlocker.tsx
+++ b/components/shared/NavigationBlocker.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface NavigationBlockerProps {
+  active: boolean
+  title?: string
+  message: string
+}
+
+/**
+ * Bloque les tentatives de navigation pendant qu'un travail est en cours.
+ * - Affiche une alerte navigateur sur fermeture/refresh d'onglet
+ * - Intercepte les clics sur les liens internes pour demander confirmation
+ */
+export function NavigationBlocker({
+  active,
+  title = 'Quitter cette page ?',
+  message,
+}: NavigationBlockerProps) {
+  const router = useRouter()
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (!target) return
+
+      const link = target.closest('a')
+      if (!link) return
+
+      const href = link.getAttribute('href')
+      if (!href) return
+
+      // Skip anchors, external protocols and same-page targets
+      if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return
+      if (link.target === '_blank') return
+
+      const currentPath = window.location.pathname
+      if (href === currentPath || href === window.location.href) return
+      if (href.startsWith(currentPath + '#') || href.startsWith(currentPath + '?')) return
+
+      // External http(s) links should also block
+      e.preventDefault()
+      e.stopPropagation()
+      setPendingHref(href)
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    document.addEventListener('click', handleClick, true)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      document.removeEventListener('click', handleClick, true)
+    }
+  }, [active])
+
+  return (
+    <AlertDialog open={!!pendingHref} onOpenChange={(open) => !open && setPendingHref(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Rester sur la page</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              if (pendingHref) {
+                if (pendingHref.startsWith('http')) {
+                  window.location.href = pendingHref
+                } else {
+                  router.push(pendingHref)
+                }
+              }
+              setPendingHref(null)
+            }}
+          >
+            Quitter quand même
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
closes #28

- Composant NavigationBlocker réutilisable (alerte navigateur + AlertDialog)
- Activé tant que le timer du module tourne et que le module n'est pas validé
- Confirmation explicite avant de quitter avec message du temps restant
- Empêche la perte de progression sur les modules à durée minimum

## Description

<!-- Décrivez brièvement les changements -->

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🔒 Sécurité
- [x] ⚡ Performance

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [x] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [ ] La documentation a été mise à jour si nécessaire
- [ ] Les migrations Prisma sont incluses si nécessaire

## Captures d'écran (si applicable)

<!-- Ajoutez des captures si c'est un changement UI -->
