### PR TITLE
Dev

### DIFF
--- a/components/learner/ModulePageClient.tsx
+++ b/components/learner/ModulePageClient.tsx
@@ -10,6 +10,7 @@ import { FeedbackModal } from './FeedbackModal'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { PageBreadcrumb } from '@/components/shared/PageBreadcrumb'
+import { NavigationBlocker } from '@/components/shared/NavigationBlocker'
 import { Loader2, PartyPopper } from 'lucide-react'
 
 interface ModuleData {
@@ -246,8 +247,22 @@ export function ModulePageClient({ data, initialQuizReview }: ModulePageClientPr
   }
 
   // Module view
+  const minutes = Math.floor(timeRemaining / 60)
+  const seconds = timeRemaining % 60
+  const remainingLabel = minutes > 0
+    ? `${minutes} min ${String(seconds).padStart(2, '0')} s`
+    : `${seconds} s`
+  const navigationBlocked =
+    !moduleCompleted && minDurationSeconds > 0 && !isTimeElapsed
+
   return (
     <div className="space-y-6">
+      <NavigationBlocker
+        active={navigationBlocked}
+        title="Quitter le module ?"
+        message={`Il vous reste ${remainingLabel} avant de pouvoir valider ce module. Si vous quittez maintenant, votre progression ne sera pas enregistrée et vous devrez recommencer.`}
+      />
+
       <PageBreadcrumb items={[
         { label: 'Mes formations', href: '/learner' },
         { label: data.module.title },

--- a/components/learner/QuizQuestion.tsx
+++ b/components/learner/QuizQuestion.tsx
@@ -165,12 +165,19 @@ export function QuizQuestion({
     onAnswerChange(questionId, pairs)
   }
 
+  // Une paire est correcte si le matchText du rightId == matchText du leftId
+  const isMatchPairCorrect = (leftId: string, rightId: string) => {
+    const left = answers.find((a) => a.id === leftId)
+    const right = answers.find((a) => a.id === rightId)
+    if (!left || !right) return false
+    return (left.matchText ?? '') === (right.matchText ?? '')
+  }
+
   const getMatchClass = (leftId: string) => {
     if (!showResult || !correctAnswers) return ''
     const selectedRight = matchSelections[leftId]
     if (!selectedRight) return ''
-    const correctPair = correctAnswers.find((c) => c.startsWith(`${leftId}:`))
-    if (correctPair === `${leftId}:${selectedRight}`) return 'border-green-500 bg-green-50 dark:bg-green-950'
+    if (isMatchPairCorrect(leftId, selectedRight)) return 'border-green-500 bg-green-50 dark:bg-green-950'
     return 'border-red-500 bg-red-50 dark:bg-red-950'
   }
 
@@ -178,8 +185,7 @@ export function QuizQuestion({
     if (!showResult || !correctAnswers) return ''
     const leftId = Object.entries(matchSelections).find(([, v]) => v === rightId)?.[0]
     if (!leftId) return ''
-    const correctPair = correctAnswers.find((c) => c.startsWith(`${leftId}:`))
-    if (correctPair === `${leftId}:${rightId}`) return 'border-green-500 bg-green-50 dark:bg-green-950'
+    if (isMatchPairCorrect(leftId, rightId)) return 'border-green-500 bg-green-50 dark:bg-green-950'
     return 'border-red-500 bg-red-50 dark:bg-red-950'
   }
 

--- a/components/shared/NavigationBlocker.tsx
+++ b/components/shared/NavigationBlocker.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface NavigationBlockerProps {
+  active: boolean
+  title?: string
+  message: string
+}
+
+/**
+ * Bloque les tentatives de navigation pendant qu'un travail est en cours.
+ * - Affiche une alerte navigateur sur fermeture/refresh d'onglet
+ * - Intercepte les clics sur les liens internes pour demander confirmation
+ */
+export function NavigationBlocker({
+  active,
+  title = 'Quitter cette page ?',
+  message,
+}: NavigationBlockerProps) {
+  const router = useRouter()
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (!target) return
+
+      const link = target.closest('a')
+      if (!link) return
+
+      const href = link.getAttribute('href')
+      if (!href) return
+
+      // Skip anchors, external protocols and same-page targets
+      if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return
+      if (link.target === '_blank') return
+
+      const currentPath = window.location.pathname
+      if (href === currentPath || href === window.location.href) return
+      if (href.startsWith(currentPath + '#') || href.startsWith(currentPath + '?')) return
+
+      // External http(s) links should also block
+      e.preventDefault()
+      e.stopPropagation()
+      setPendingHref(href)
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    document.addEventListener('click', handleClick, true)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      document.removeEventListener('click', handleClick, true)
+    }
+  }, [active])
+
+  return (
+    <AlertDialog open={!!pendingHref} onOpenChange={(open) => !open && setPendingHref(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Rester sur la page</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              if (pendingHref) {
+                if (pendingHref.startsWith('http')) {
+                  window.location.href = pendingHref
+                } else {
+                  router.push(pendingHref)
+                }
+              }
+              setPendingHref(null)
+            }}
+          >
+            Quitter quand même
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/lib/services/quiz.service.ts
+++ b/lib/services/quiz.service.ts
@@ -190,11 +190,22 @@ export async function submitQuiz(
         correctAnswers: correctOrder,
       })
     } else if (question.type === 'MATCHING') {
-      // Pour l'association : format "leftId:rightId", correct = leftId:leftId (même answer)
+      // Format "leftId:rightId". Une paire est correcte si le matchText du rightId
+      // correspond au matchText attendu par le leftId (tolère les doublons de matchText).
+      const answersById = new Map(question.answers.map((a) => [a.id, a]))
       const correctPairs = question.answers.map((a) => `${a.id}:${a.id}`)
+
+      const isPairCorrect = (pair: string) => {
+        const [leftId, rightId] = pair.split(':')
+        const left = answersById.get(leftId)
+        const right = answersById.get(rightId)
+        if (!left || !right) return false
+        return (left.matchText ?? '') === (right.matchText ?? '')
+      }
+
       const isCorrect =
-        selectedAnswerIds.length === correctPairs.length &&
-        correctPairs.every((pair) => selectedAnswerIds.includes(pair))
+        selectedAnswerIds.length === question.answers.length &&
+        selectedAnswerIds.every(isPairCorrect)
       if (isCorrect) correctCount++
       results.push({
         questionId: question.id,


### PR DESCRIPTION
closes #27
closes #28

### Bugs corrigés

- **#27** Quiz association : matchText en doublon ne pénalisent plus l'apprenant
- **#28** Module avec timer : confirmation requise avant de quitter

## Description

Deux corrections de bugs identifiés sur les premiers tests utilisateurs : la logique de scoring des quiz d'association tolère maintenant les textes de correspondance identiques, et la navigation pendant le timer minimum d'un module est désormais protégée par une confirmation pour éviter les pertes de progression.

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🔒 Sécurité
- [ ] ⚡ Performance

## Checklist

- [x] Le code compile sans erreur (`pnpm typecheck`)
- [x] Le lint passe (`pnpm lint`)
- [ ] Les tests passent (`pnpm test`)
- [x] La fonctionnalité a été testée manuellement
- [ ] La documentation a été mise à jour si nécessaire
- [ ] Les migrations Prisma sont incluses si nécessaire

## Captures d'écran (si applicable)

N/A
